### PR TITLE
Issue #50 correctly handle process renaming when merging two graph builders in ImageCollectionClient._reducte_bands_binary

### DIFF
--- a/openeo/graphbuilder.py
+++ b/openeo/graphbuilder.py
@@ -63,7 +63,7 @@ class GraphBuilder():
     def _merge_processes(self, processes:Dict):
         key_map = {}
         node_refs = []
-        for key,process in processes.items():
+        for key,process in sorted(processes.items()):
             process_id = process['process_id']
             args = process['arguments']
             result = process.get('result', None)

--- a/openeo/rest/imagecollectionclient.py
+++ b/openeo/rest/imagecollectionclient.py
@@ -309,6 +309,8 @@ class ImageCollectionClient(ImageCollection):
                 merged.add_process(operator, data=[input_node, {'from_node': current_result}], result=True)
         else:
             input1 = my_builder.processes[my_builder.find_result_node_id()]
+            # TODO (issue #50) this logic assumes that `input1` will be present unaffected in the merged graph,
+            #      which is not guaranteed because of possible renaming of `from_node` fields.
             merged = my_builder.merge(other_builder)
             input1_id = list(merged.processes.keys())[list(merged.processes.values()).index(input1)]
             merged.processes[input1_id]['result'] = False

--- a/openeo/rest/imagecollectionclient.py
+++ b/openeo/rest/imagecollectionclient.py
@@ -291,33 +291,14 @@ class ImageCollectionClient(ImageCollection):
         else:
             raise ValueError("Unsupported right-hand operand: " + str(other))
 
-    def _reduce_bands_binary(self, operator, other):
+    def _reduce_bands_binary(self, operator, other: 'ImageCollectionClient'):
         # first we create the callback
+        fallback_node = {'from_argument': 'data'}
         my_builder = self._get_band_graph_builder()
         other_builder = other._get_band_graph_builder()
-        input_node = {'from_argument': 'data'}
-        if my_builder == None or other_builder == None:
-            if my_builder == None and other_builder == None:
-                merged = GraphBuilder()
-                # TODO merge both process graphs?
-                merged.add_process( operator, data=[input_node, input_node], result=True)
-            else:
-                merged = my_builder or other_builder
-                merged = merged.copy()
-                current_result = merged.find_result_node_id()
-                merged.processes[current_result]['result'] = False
-                merged.add_process(operator, data=[input_node, {'from_node': current_result}], result=True)
-        else:
-            input1 = my_builder.processes[my_builder.find_result_node_id()]
-            # TODO (issue #50) this logic assumes that `input1` will be present unaffected in the merged graph,
-            #      which is not guaranteed because of possible renaming of `from_node` fields.
-            merged = my_builder.merge(other_builder)
-            input1_id = list(merged.processes.keys())[list(merged.processes.values()).index(input1)]
-            merged.processes[input1_id]['result'] = False
-            input2_id = merged.find_result_node_id()
-            input2 = merged.processes[input2_id]
-            input2['result'] = False
-            merged.add_process(operator, data=[{'from_node': input1_id}, {'from_node': input2_id}], result=True)
+        merged = GraphBuilder.combine(operator=operator,
+                                      first=my_builder or fallback_node,
+                                      second=other_builder or fallback_node)
         # callback is ready, now we need to properly set up the reduce process that will invoke it
         if my_builder == None and other_builder == None:
             # there was no previous reduce step

--- a/tests/test_graphbuilder.py
+++ b/tests/test_graphbuilder.py
@@ -97,3 +97,17 @@ class GraphBuilderTest(TestCase):
         self.assertIn("sum3", merged)
         self.assertEqual("sum2",merged["sum3"]["arguments"]["data"]["from_node"])
         self.assertEqual("sum2", merged["sum3"]["arguments"]["data2"][0]["from_node"])
+
+    def test_merge_issue50(self):
+        """https://github.com/Open-EO/openeo-python-client/issues/50"""
+        graph = {
+            'op3': {'process_id': 'op', 'arguments': {'data': {'from_node': 'op1', 'ref': 'A'}}},
+            'op2': {'process_id': 'op', 'arguments': {'data': {'from_node': 'src', 'ref': 'B'}}},
+            'op1': {'process_id': 'op', 'arguments': {'data': {'from_node': 'op2', 'ref': 'C'}}},
+            'op4': {'process_id': 'op', 'arguments': {'data': {'from_node': 'op3', 'ref': 'D'}}},
+        }
+        builder = GraphBuilder(graph)
+        assert builder.processes['op1']['arguments']['data'] == {'from_node': 'op2', 'ref': 'C'}
+        assert builder.processes['op2']['arguments']['data'] == {'from_node': 'src', 'ref': 'B'}
+        assert builder.processes['op3']['arguments']['data'] == {'from_node': 'op1', 'ref': 'A'}
+        assert builder.processes['op4']['arguments']['data'] == {'from_node': 'op3', 'ref': 'D'}


### PR DESCRIPTION
quickfix for issue #50

Explicitly sort source graph items in merge functionality of GraphBuilder to minimize node key ("from_node") renaming