### PR TITLE
use `load_collection` instead of `get_connection` for API version 0.4.0 and above

### DIFF
--- a/tests/aggregate_zonal.json
+++ b/tests/aggregate_zonal.json
@@ -1,9 +1,11 @@
 {
   "process_graph": {
-    "getcollection1": {
-      "process_id": "get_collection",
+    "loadcollection1": {
+      "process_id": "load_collection",
       "arguments": {
-        "name": "SENTINEL2_FAPAR"
+        "id": "SENTINEL2_FAPAR",
+        "spatial_extent": null,
+        "temporal_extent": null
       },
       "result": false
     },
@@ -11,7 +13,7 @@
       "process_id": "filter_bbox",
       "arguments": {
         "data": {
-          "from_node": "getcollection1"
+          "from_node": "loadcollection1"
         },
         "west": 3,
         "east": 6,

--- a/tests/apply_dimension_temporal_cumsum.json
+++ b/tests/apply_dimension_temporal_cumsum.json
@@ -1,8 +1,10 @@
 {
-  "getcollection1": {
-    "process_id": "get_collection",
+  "loadcollection1": {
+    "process_id": "load_collection",
     "arguments": {
-      "name": "SENTINEL2_RADIOMETRY_10M"
+      "id": "SENTINEL2_RADIOMETRY_10M",
+      "spatial_extent": null,
+      "temporal_extent": null
     },
     "result": false
   },
@@ -10,7 +12,7 @@
     "process_id": "apply_dimension",
     "arguments": {
       "data": {
-        "from_node": "getcollection1"
+        "from_node": "loadcollection1"
       },
       "dimension": "temporal",
       "process": {

--- a/tests/evi_graph.json
+++ b/tests/evi_graph.json
@@ -1,8 +1,10 @@
 {
-  "getcollection1": {
-    "process_id": "get_collection",
+  "loadcollection1": {
+    "process_id": "load_collection",
     "arguments": {
-      "name": "SENTINEL2_RADIOMETRY_10M"
+      "id": "SENTINEL2_RADIOMETRY_10M",
+      "spatial_extent": null,
+      "temporal_extent": null
     },
     "result": false
   },
@@ -10,7 +12,7 @@
     "process_id": "reduce",
     "arguments": {
       "data": {
-        "from_node": "getcollection1"
+        "from_node": "loadcollection1"
       },
       "dimension": "spectral_bands",
       "reducer": {

--- a/tests/notequal.json
+++ b/tests/notequal.json
@@ -1,8 +1,10 @@
 {
-  "getcollection1": {
-    "process_id": "get_collection",
+  "loadcollection1": {
+    "process_id": "load_collection",
     "arguments": {
-      "name": "SENTINEL2_SCF"
+      "id": "SENTINEL2_SCF",
+      "spatial_extent": null,
+      "temporal_extent": null
     },
     "result": false
   },
@@ -10,7 +12,7 @@
     "process_id": "reduce",
     "arguments": {
       "data": {
-        "from_node": "getcollection1"
+        "from_node": "loadcollection1"
       },
       "dimension": "spectral_bands",
       "reducer": {

--- a/tests/test_bandmath.py
+++ b/tests/test_bandmath.py
@@ -53,10 +53,8 @@ class TestBandMath(TestCase):
 
         session.download.assert_called_once()
         actual_graph = session.download.call_args_list[0][0][0]
-        import json
-        print(json.dumps(actual_graph,indent=2))
         expected_graph = load_json_resource('evi_graph.json')
-        self.assertDictEqual(expected_graph,actual_graph)
+        assert actual_graph == expected_graph
 
 
     def test_ndvi(self, m):
@@ -176,11 +174,9 @@ class TestBandMath(TestCase):
                                                                                'time': {'from': '2015-06-23',
                                                                                         'to': '2018-06-18'}})
 
-        expected_graph = load_json_resource('udf_graph.json')
         def check_process_graph(request):
-            import json
-            print(json.dumps(request.json(),indent=2))
-            self.assertDictEqual(expected_graph,request.json())
+            expected_graph = load_json_resource('udf_graph.json')
+            assert request.json() == expected_graph
             return True
 
         m.post("http://localhost:8000/api/result", text="my binary data", additional_matcher=check_process_graph)

--- a/tests/test_logical_operators.py
+++ b/tests/test_logical_operators.py
@@ -47,7 +47,5 @@ class TestLogicalOps(TestCase):
 
         session.download.assert_called_once()
         actual_graph = session.download.call_args_list[0][0][0]
-        import json
-        print(json.dumps(actual_graph,indent=2))
         expected_graph = load_json_resource('notequal.json')
-        self.assertDictEqual(expected_graph,actual_graph)
+        assert actual_graph == expected_graph

--- a/tests/test_temporal_ops.py
+++ b/tests/test_temporal_ops.py
@@ -47,7 +47,5 @@ class TestTemporal(TestCase):
 
         session.download.assert_called_once()
         actual_graph = session.download.call_args_list[0][0][0]
-        import json
-        print(json.dumps(actual_graph, indent=2))
         expected_graph = load_json_resource('apply_dimension_temporal_cumsum.json')
-        self.assertDictEqual(expected_graph, actual_graph)
+        assert actual_graph == expected_graph

--- a/tests/test_zonal_stats.py
+++ b/tests/test_zonal_stats.py
@@ -43,12 +43,10 @@ class TestTimeSeries(TestCase):
         #access multiband 4D (x/y/time/band) coverage
         fapar = session.imagecollection("SENTINEL2_FAPAR").bbox_filter(3,6,52,50,"EPSG:4326")
 
-        expected_graph = load_json('aggregate_zonal.json')
 
         def check_process_graph(request):
-            import json
-            print(json.dumps(request.json(), indent=2))
-            self.assertDictEqual(expected_graph, request.json())
+            expected_graph = load_json('aggregate_zonal.json')
+            assert request.json() == expected_graph
             return True
 
         m.post("http://localhost:8000/api/result", json={}, additional_matcher=check_process_graph)

--- a/tests/udf_graph.json
+++ b/tests/udf_graph.json
@@ -1,9 +1,11 @@
 {
   "process_graph": {
-    "getcollection1": {
-      "process_id": "get_collection",
+    "loadcollection1": {
+      "process_id": "load_collection",
       "arguments": {
-        "name": "SENTINEL2_RADIOMETRY_10M"
+        "id": "SENTINEL2_RADIOMETRY_10M",
+        "spatial_extent": null,
+        "temporal_extent": null
       },
       "result": false
     },
@@ -11,7 +13,7 @@
       "process_id": "reduce",
       "arguments": {
         "data": {
-          "from_node": "getcollection1"
+          "from_node": "loadcollection1"
         },
         "dimension": "spectral_bands",
         "binary": "false",


### PR DESCRIPTION
- use "load_collection" instead of "get_collection" for API version >= 0.4.0
- in unit tests: just use `assert a == b` instead of `print(json.dumps(...)); self.assertDictEqual(...)` as pytest  already gives actionable difference information by default