### PR TITLE
Add "api_version" to Capabilties and make (API) version checking more generic

### DIFF
--- a/openeo/capabilities.py
+++ b/openeo/capabilities.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from distutils.version import LooseVersion
 
 
 class Capabilities(ABC):
@@ -17,6 +18,11 @@ class Capabilities(ABC):
         """Get OpenEO API version."""
         # Field: api_version
         return
+
+    @property
+    def api_version_check(self):
+        """Helper to easily check if the API version is at least or below some threshold version."""
+        return CheckableVersion(self.api_version())
 
     def list_features(self):
         """ List all supported features / endpoints."""
@@ -37,3 +43,35 @@ class Capabilities(ABC):
         """ List all billing plans."""
         # Field: billing > plans
         pass
+
+
+class CheckableVersion:
+    """
+    Helper to check a version (e.g. API version) against another (threshold) version
+
+    >>> v = CheckableVersion('1.2.3')
+    >>> v.at_least('1.2.1')
+    True
+    >>> v.at_least('1.10.2')
+    False
+    """
+    def __init__(self, version):
+        self._version = LooseVersion(version)
+
+    def __str__(self):
+        return str(self._version)
+
+    def to_string(self):
+        return str(self)
+
+    def at_least(self, version):
+        return self._version >= LooseVersion(version)
+
+    def above(self, version):
+        return self._version > LooseVersion(version)
+
+    def at_most(self, version):
+        return self._version <= LooseVersion(version)
+
+    def below(self, version):
+        return self._version < LooseVersion(version)

--- a/openeo/capabilities.py
+++ b/openeo/capabilities.py
@@ -8,9 +8,15 @@ class Capabilities(ABC):
         pass
 
     def version(self):
-        """ Get openEO version."""
+        """ Get openEO version. DEPRECATED: use api_version instead"""
         # Field: version
-        pass
+        # TODO: raise deprecation warning here?
+        return self.api_version()
+
+    def api_version(self):
+        """Get OpenEO API version."""
+        # Field: api_version
+        return
 
     def list_features(self):
         """ List all supported features / endpoints."""

--- a/openeo/rest/imagecollectionclient.py
+++ b/openeo/rest/imagecollectionclient.py
@@ -1,5 +1,4 @@
 import copy
-from distutils.version import LooseVersion
 from typing import List, Dict, Union
 
 from datetime import datetime, date
@@ -25,8 +24,9 @@ class ImageCollectionClient(ImageCollection):
         self.graph = builder.processes
         self.bands = []
 
-    def _isVersion040(self):
-        return LooseVersion(self.session.capabilities().version()) >= LooseVersion("0.4.0")
+    @property
+    def _api_version(self):
+        return self.session.capabilities().api_version_check
 
     @classmethod
     def create_collection(cls, collection_id:str,session:Connection = None):
@@ -391,7 +391,7 @@ class ImageCollectionClient(ImageCollection):
         :raises: CardinalityChangedError
         """
 
-        if self._isVersion040():
+        if self._api_version.at_least('0.4.0'):
             process_id = 'apply_dimension'
             if runtime !=None:
 
@@ -438,7 +438,7 @@ class ImageCollectionClient(ImageCollection):
             :param code: String representing Python code to be executed in the backend.
         """
 
-        if self._isVersion040():
+        if self._api_version.at_least('0.4.0'):
             process_id = 'reduce'
             args = {
                 'data': {
@@ -491,7 +491,7 @@ class ImageCollectionClient(ImageCollection):
         :param version: The UDF runtime version
         :return:
         """
-        if self._isVersion040():
+        if self._api_version.at_least('0.4.0'):
             process_id = 'reduce'
             args = {
                 'data': {
@@ -699,7 +699,7 @@ class ImageCollectionClient(ImageCollection):
         }
 
         process_id = 'aggregate_zonal'
-        if self._isVersion040():
+        if self._api_version.at_least('0.4.0'):
             process_id = 'aggregate_polygon'
 
         args = {
@@ -707,7 +707,7 @@ class ImageCollectionClient(ImageCollection):
                 'dimension':'temporal',
                 'polygons': geojson
             }
-        if self._isVersion040():
+        if self._api_version.at_least('0.4.0'):
             del args['dimension']
             args['reducer']= {
                 'callback':{
@@ -728,7 +728,7 @@ class ImageCollectionClient(ImageCollection):
     def download(self, outputfile:str, bbox="", time="", **format_options) -> str:
         """Extraxts a geotiff from this image collection."""
 
-        if self._isVersion040():
+        if self._api_version.at_least('0.4.0'):
             args = {
                 'data': {'from_node': self.node_id},
                 'options': format_options

--- a/openeo/rest/rest_capabilities.py
+++ b/openeo/rest/rest_capabilities.py
@@ -7,12 +7,13 @@ class RESTCapabilities(Capabilities):
     def __init__(self, data):
         self.capabilities = data
 
-    def version(self):
+    def api_version(self):
         """ Get openEO version."""
-        if "version" in self.capabilities:
-            return self.capabilities["version"]
-
-        return None
+        if 'api_version' in self.capabilities:
+            return self.capabilities.get('api_version')
+        else:
+            # Legacy/deprecated
+            return self.capabilities.get('version')
 
     def list_features(self):
         """ List all supported features / endpoints."""

--- a/openeo/rest/rest_connection.py
+++ b/openeo/rest/rest_connection.py
@@ -1,10 +1,10 @@
 import json
 import shutil
-from distutils.version import LooseVersion
 
 import requests
 from openeo.auth.auth_basic import BasicAuth
 from openeo.auth.auth_none import NoneAuth
+from openeo.capabilities import Capabilities
 from openeo.connection import Connection
 from openeo.rest.job import RESTJob
 from openeo.rest.rest_capabilities import RESTCapabilities
@@ -228,8 +228,9 @@ class RESTConnection(Connection):
 
         return processes_dict
 
-    def _isVersion040(self):
-        return LooseVersion(self.capabilities().version()) >= LooseVersion("0.4.0")
+    @property
+    def _api_version(self):
+        return self.capabilities().api_version_check
 
     def imagecollection(self, image_collection_id) -> 'ImageCollection':
         """
@@ -237,7 +238,7 @@ class RESTConnection(Connection):
         :param image_collection_id: String image collection identifier
         :return: collection: RestImageCollection the imagecollection with the id
         """
-        if self._isVersion040():
+        if self._api_version.at_least('0.4.0'):
             return self._image_040(image_collection_id)
         else:
             from .imagery import RestImagery
@@ -351,7 +352,7 @@ class RESTConnection(Connection):
         request = {
             "process_graph": graph
         }
-        if self._isVersion040():
+        if self._api_version.at_least('0.4.0'):
             path = "/result"
         else:
             request["output"] = format_options
@@ -378,7 +379,7 @@ class RESTConnection(Connection):
         """
         # TODO: add output_format to execution
         path = "/preview"
-        if self._isVersion040():
+        if self._api_version.at_least('0.4.0'):
             path = "/result"
         response = self.post(self.root + path, process_graph)
         return self.parse_json_response(response)

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,41 @@
+from openeo.capabilities import CheckableVersion
+
+
+def test_checkable_version():
+    v = CheckableVersion('1.2.3')
+    assert v.above('0')
+    assert v.above('0.1')
+    assert v.above('0.1.2')
+    assert v.above('1.2')
+    assert v.above('1.2.2')
+    assert v.above('1.2.2b')
+    assert v.above('1.2.3') is False
+    assert v.above('1.2.20') is False
+    assert v.above('1.2.4') is False
+    assert v.above('1.10.4') is False
+    assert v.at_least('0')
+    assert v.at_least('1')
+    assert v.at_least('1.1')
+    assert v.at_least('1.10') is False
+    assert v.at_least('1.2')
+    assert v.at_least('1.02')
+    assert v.at_least('1.2.2')
+    assert v.at_least('1.2.3')
+    assert v.at_least('1.2.3a') is False
+    assert v.at_least('1.2.4') is False
+    assert v.at_least('1.3') is False
+    assert v.at_least('2') is False
+    assert v.below('2')
+    assert v.below('1.3')
+    assert v.below('1.2.4')
+    assert v.below('1.2.3b')
+    assert v.below('1.2.3') is False
+    assert v.below('1.2') is False
+    assert v.at_most('2')
+    assert v.at_most('1.3')
+    assert v.at_most('1.2.3c')
+    assert v.at_most('1.2.3')
+    assert v.at_most('1.02.03')
+    assert v.at_most('1.2.2b') is False
+    assert v.at_most('1.2') is False
+    assert v.at_most('1.10')

--- a/tests/test_rest_session.py
+++ b/tests/test_rest_session.py
@@ -127,6 +127,19 @@ class TestUserFiles(TestCase):
         capabilities = con.capabilities()
         assert capabilities.capabilities == CAPABILITIES
 
+    def test_capabilities_api_version(self, m):
+        capabilties_url = "{}/".format(self.endpoint)
+        # Old-style api
+        m.register_uri('GET', capabilties_url, json={'version': '0.3.1'})
+        capabilities = openeo.connect(self.endpoint).capabilities()
+        assert capabilities.version() == '0.3.1'
+        assert capabilities.api_version() == '0.3.1'
+        # 0.4.0 style api
+        m.register_uri('GET', capabilties_url, json={'api_version': '0.4.0'})
+        capabilities = openeo.connect(self.endpoint).capabilities()
+        assert capabilities.version() == '0.4.0'
+        assert capabilities.api_version() == '0.4.0'
+
     def test_list_collections(self, m):
         collection_url = "{}/collections".format(self.endpoint)
         m.register_uri('GET', collection_url, json=COLLECTIONS)

--- a/tests/test_rest_session.py
+++ b/tests/test_rest_session.py
@@ -140,6 +140,20 @@ class TestUserFiles(TestCase):
         assert capabilities.version() == '0.4.0'
         assert capabilities.api_version() == '0.4.0'
 
+    def test_capabilities_api_version_check(self, m):
+        capabilties_url = "{}/".format(self.endpoint)
+        m.register_uri('GET', capabilties_url, json={'api_version': '1.2.3'})
+        capabilities = openeo.connect(self.endpoint).capabilities()
+        assert capabilities.api_version_check.below('1.2.4')
+        assert capabilities.api_version_check.below('1.1') is False
+        assert capabilities.api_version_check.at_most('1.3')
+        assert capabilities.api_version_check.at_most('1.2.3')
+        assert capabilities.api_version_check.at_most('1.2.2') is False
+        assert capabilities.api_version_check.at_least('1.2.3')
+        assert capabilities.api_version_check.at_least('1.5') is False
+        assert capabilities.api_version_check.above('1.2.3') is False
+        assert capabilities.api_version_check.above('1.2.2')
+
     def test_list_collections(self, m):
         collection_url = "{}/collections".format(self.endpoint)
         m.register_uri('GET', collection_url, json=COLLECTIONS)


### PR DESCRIPTION
Two things in this PR:
- add "api_version" to Capabilities and deprecating "version" field (following 0.4.0 API)
- make the API version checking more generic for future usage (not only 0.4.0)