### PR TITLE
Band math: add support for logical and/or operations

### DIFF
--- a/openeo/rest/imagecollectionclient.py
+++ b/openeo/rest/imagecollectionclient.py
@@ -48,7 +48,7 @@ class ImageCollectionClient(ImageCollection):
         # TODO: rename function to load_collection for better similarity with corresponding process id?
         builder = GraphBuilder()
 
-        if LooseVersion(session.capabilities().version()) >= LooseVersion('0.4.0'):
+        if session.capabilities().api_version_check.at_least('0.4.0'):
             process_id = 'load_collection'
             arguments = {
                 'id': collection_id,

--- a/openeo/rest/imagecollectionclient.py
+++ b/openeo/rest/imagecollectionclient.py
@@ -204,6 +204,22 @@ class ImageCollectionClient(ImageCollection):
         else:
             raise ValueError("Unsupported right-hand operand: " + str(other))
 
+    def logical_or(self, other: ImageCollection):
+        """
+        Apply element-wise logical `or` operation
+        :param other:
+        :return ImageCollection: logical_or(this, other)
+        """
+        return self._reduce_bands_binary(operator='or', other=other)
+
+    def logical_and(self, other: ImageCollection):
+        """
+        Apply element-wise logical `and` operation
+        :param other:
+        :return ImageCollection: logical_and(this, other)
+        """
+        return self._reduce_bands_binary(operator='and', other=other)
+
     def __invert__(self):
         """
 
@@ -213,6 +229,7 @@ class ImageCollectionClient(ImageCollection):
         my_builder = self._get_band_graph_builder()
         new_builder = None
         extend_previous_callback_graph = my_builder is not None
+        # TODO: why does these `add_process` calls use "expression" instead of "data" like the other cases?
         if not extend_previous_callback_graph:
             new_builder = GraphBuilder()
             # TODO merge both process graphs?
@@ -291,6 +308,12 @@ class ImageCollectionClient(ImageCollection):
 
     def __rmul__(self, other):
         return self.product(other)
+
+    def __or__(self, other):
+        return self.logical_or(other)
+
+    def __and__(self, other):
+        return  self.logical_and(other)
 
     def add(self, other:Union[ImageCollection,Union[int,float]]):
         """

--- a/openeo/rest/rest_connection.py
+++ b/openeo/rest/rest_connection.py
@@ -271,6 +271,7 @@ class RESTConnection(Connection):
         return image
 
     def fetch_metadata(self, image_product_id, image_collection):
+        # TODO: this sets public properties on image_collection: shouldn't this be part of ImageCollection class then?
         # read and format extent, band and date availability information
         data_info = self.describe_collection(image_product_id)
         image_collection.bands = []

--- a/tests/logical_and.json
+++ b/tests/logical_and.json
@@ -1,0 +1,89 @@
+{
+  "loadcollection1": {
+    "process_id": "load_collection",
+    "arguments": {
+      "id": "SENTINEL2_SCF",
+      "spatial_extent": null,
+      "temporal_extent": null
+    },
+    "result": false
+  },
+  "reduce1": {
+    "process_id": "reduce",
+    "arguments": {
+      "data": {
+        "from_node": "loadcollection1"
+      },
+      "dimension": "spectral_bands",
+      "reducer": {
+        "callback": {
+          "arrayelement1": {
+            "process_id": "array_element",
+            "arguments": {
+              "data": {
+                "from_argument": "data"
+              },
+              "index": 0
+            },
+            "result": false
+          },
+          "arrayelement2": {
+            "process_id": "array_element",
+            "arguments": {
+              "data": {
+                "from_argument": "data"
+              },
+              "index": 1
+            },
+            "result": false
+          },
+          "eq1": {
+            "process_id": "eq",
+            "arguments": {
+              "x": {
+                "from_node": "arrayelement1"
+              },
+              "y": 2
+            },
+            "result": false
+          },
+          "eq2": {
+            "process_id": "eq",
+            "arguments": {
+              "x": {
+                "from_node": "arrayelement2"
+              },
+              "y": 5
+            },
+            "result": false
+          },
+          "and1": {
+            "process_id": "and",
+            "arguments": {
+              "data": [
+                {
+                  "from_node": "eq1"
+                },
+                {
+                  "from_node": "eq2"
+                }
+              ]
+            },
+            "result": true
+          }
+        }
+      }
+    },
+    "result": false
+  },
+  "saveresult1": {
+    "process_id": "save_result",
+    "arguments": {
+      "data": {
+        "from_node": "reduce1"
+      },
+      "options": {}
+    },
+    "result": "true"
+  }
+}

--- a/tests/logical_or.json
+++ b/tests/logical_or.json
@@ -1,0 +1,89 @@
+{
+  "loadcollection1": {
+    "process_id": "load_collection",
+    "arguments": {
+      "id": "SENTINEL2_SCF",
+      "spatial_extent": null,
+      "temporal_extent": null
+    },
+    "result": false
+  },
+  "reduce1": {
+    "process_id": "reduce",
+    "arguments": {
+      "data": {
+        "from_node": "loadcollection1"
+      },
+      "dimension": "spectral_bands",
+      "reducer": {
+        "callback": {
+          "arrayelement1": {
+            "process_id": "array_element",
+            "arguments": {
+              "data": {
+                "from_argument": "data"
+              },
+              "index": 0
+            },
+            "result": false
+          },
+          "arrayelement2": {
+            "process_id": "array_element",
+            "arguments": {
+              "data": {
+                "from_argument": "data"
+              },
+              "index": 0
+            },
+            "result": false
+          },
+          "eq1": {
+            "process_id": "eq",
+            "arguments": {
+              "x": {
+                "from_node": "arrayelement1"
+              },
+              "y": 2
+            },
+            "result": false
+          },
+          "eq2": {
+            "process_id": "eq",
+            "arguments": {
+              "x": {
+                "from_node": "arrayelement2"
+              },
+              "y": 5
+            },
+            "result": false
+          },
+          "or1": {
+            "process_id": "or",
+            "arguments": {
+              "data": [
+                {
+                  "from_node": "eq1"
+                },
+                {
+                  "from_node": "eq2"
+                }
+              ]
+            },
+            "result": true
+          }
+        }
+      }
+    },
+    "result": false
+  },
+  "saveresult1": {
+    "process_id": "save_result",
+    "arguments": {
+      "data": {
+        "from_node": "reduce1"
+      },
+      "options": {}
+    },
+    "result": "true"
+  }
+}

--- a/tests/test_logical_operators.py
+++ b/tests/test_logical_operators.py
@@ -23,7 +23,7 @@ def load_json_resource(relative_path):
 @requests_mock.mock()
 class TestLogicalOps(TestCase):
 
-    def test_not_equal(self,m):
+    def test_not_equal(self, m):
         # configuration phase: define username, endpoint, parameters?
         session = openeo.connect("http://localhost:8000/api")
         session.post = MagicMock()
@@ -31,9 +31,11 @@ class TestLogicalOps(TestCase):
 
         m.get("http://localhost:8000/api/", json={"version": "0.4.0"})
         m.get("http://localhost:8000/api/collections", json={"collections": [{"product_id": "sentinel2_subset"}]})
-        m.get("http://localhost:8000/api/collections/SENTINEL2_SCF", json={"product_id": "sentinel2_subset",
-                                                                                      "bands": [{'band_id': 'SCENECLASSIFICATION'}],
-                                                                                      'time': {'from': '2015-06-23','to': '2018-06-18'}})
+        m.get("http://localhost:8000/api/collections/SENTINEL2_SCF", json={
+            "product_id": "sentinel2_subset",
+            "bands": [{'band_id': 'SCENECLASSIFICATION'}],
+            'time': {'from': '2015-06-23', 'to': '2018-06-18'}
+        })
 
         # discovery phase: find available data
         # basically user needs to find available data on a website anyway?
@@ -44,11 +46,59 @@ class TestLogicalOps(TestCase):
 
         scf_bands = s2_radio.band('SCENECLASSIFICATION')
 
-        mask = scf_bands !=4
+        mask = scf_bands != 4
 
         mask.download("out.geotiff", bbox="", time=s2_radio.dates['to'])
 
         session.download.assert_called_once()
         actual_graph = session.download.call_args_list[0][0][0]
         expected_graph = load_json_resource('notequal.json')
+        assert actual_graph == expected_graph
+
+    def test_or(self, m):
+        session = openeo.connect("http://localhost:8000/api")
+        session.post = MagicMock()
+        session.download = MagicMock()
+
+        m.get("http://localhost:8000/api/", json={"version": "0.4.0"})
+        m.get("http://localhost:8000/api/collections", json={"collections": [{"product_id": "sentinel2_subset"}]})
+        m.get("http://localhost:8000/api/collections/SENTINEL2_SCF", json={
+            "product_id": "sentinel2_subset",
+            "bands": [{'band_id': 'SCENECLASSIFICATION'}],
+            'time': {'from': '2015-06-23', 'to': '2018-06-18'}
+        })
+
+        ic = session.imagecollection("SENTINEL2_SCF")
+        data = ic.band('SCENECLASSIFICATION')
+        # TODO: this expression (twice `data`) creates a duplicate `arrayelement` in the process graph
+        mask = (data == 2) | (data == 5)
+
+        mask.download("out.geotiff", bbox="", time=ic.dates['to'])
+        session.download.assert_called_once()
+        actual_graph = session.download.call_args_list[0][0][0]
+        expected_graph = load_json_resource('logical_or.json')
+        assert actual_graph == expected_graph
+
+    def test_and(self, m):
+        session = openeo.connect("http://localhost:8000/api")
+        session.post = MagicMock()
+        session.download = MagicMock()
+
+        m.get("http://localhost:8000/api/", json={"version": "0.4.0"})
+        m.get("http://localhost:8000/api/collections", json={"collections": [{"product_id": "sentinel2_subset"}]})
+        m.get("http://localhost:8000/api/collections/SENTINEL2_SCF", json={
+            "product_id": "sentinel2_subset",
+            "bands": [{'band_id': 'B1'}, {'band_id': 'B2'}],
+            'time': {'from': '2015-06-23', 'to': '2018-06-18'}
+        })
+
+        ic = session.imagecollection("SENTINEL2_SCF")
+        b1 = ic.band('B1')
+        b2 = ic.band('B2')
+        mask = (b1 == 2) & (b2 == 5)
+
+        mask.download("out.geotiff", bbox="", time=ic.dates['to'])
+        session.download.assert_called_once()
+        actual_graph = session.download.call_args_list[0][0][0]
+        expected_graph = load_json_resource('logical_and.json')
         assert actual_graph == expected_graph


### PR DESCRIPTION
as discussed with @jdries : this commit adds support for numpy/pandas style and/or logical operations, e.g.

     mask = (data == 2) | (data == 5)