### PR TITLE
Simplify `ProcessGraphVisitor._list_to_graph` and rename to `dereference_from_node_arguments`

### DIFF
--- a/openeo/internal/process_graph_visitor.py
+++ b/openeo/internal/process_graph_visitor.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import  ABC
 from typing import Dict
 
@@ -12,39 +13,45 @@ class ProcessGraphVisitor(ABC):
 
     @classmethod
     def _list_to_graph(cls,processGraph):
+        # TODO remove this function when not used anymore in openeo-python-driver
+        warnings.warn("_list_to_graph is deprecated, use dereference_node_arguments instead.", DeprecationWarning)
+        return cls.dereference_from_node_arguments(processGraph)
+
+    @classmethod
+    def dereference_from_node_arguments(cls, process_graph:dict) -> str:
         """
-        Converts a list of process graph nodes into an actual graph, by resolving the references.
-        :param processGraph:
-        :return: a list containing the top level nodes in the DAG
+        Walk through the given process graph and replace (in-place) "from_node" references in
+        process arguments (dictionaries or lists) with the corresponding resolved subgraphs
+
+        :param process_graph: process graph dictionary to be manipulated in-place
+        :return: name of the "result" node of the graph
         """
+        # TODO avoid manipulating process graph in place? make it more explicit? work on a copy? Where is this functionality used anyway?
+
+        def resolve_from_node(process_graph, node, from_node):
+            if from_node not in process_graph:
+                raise ValueError('from_node {f!r} (referenced by {n!r}) not in process graph.'.format(
+                    f=from_node, n=node))
+            return process_graph[from_node]
+
         result_node = None
-        for node in processGraph:
-            node_dict = processGraph.get(node)
-            if (node_dict.get("result", False)):
+        for node, node_dict in process_graph.items():
+            if node_dict.get("result", False):
+                assert result_node is None
                 result_node = node
             arguments = node_dict.get("arguments", {})
-            for a in arguments:
-                arg = arguments[a]
-                if type(arg) is dict and "from_node" in arg:
-                    from_node_id = arg["from_node"]
-                    from_node = processGraph.get(from_node_id, None)
-                    if (from_node is None):
-                        raise ValueError(
-                            "Node not found in process graph: " + from_node_id + ". Referenced by: " + node)
-                    arg["node"] = from_node
-                elif type(arg) is list:
-                    for num, element in enumerate(arg):
-                        if type(element) == dict and "from_node" in element:
-                            from_node_id = element["from_node"]
-                            from_node = processGraph.get(from_node_id, None)
-                            if (from_node is None):
-                                raise ValueError(
-                                    "Node not found in process graph: " + from_node_id + ". Referenced by: " + node)
-                            arg[num] = from_node
+            for arg in arguments.values():
+                if isinstance(arg, dict) and "from_node" in arg:
+                    arg["node"] = resolve_from_node(process_graph, node, arg["from_node"])
+                elif isinstance(arg, list):
+                    for i, element in enumerate(arg):
+                        if isinstance(element, dict) and "from_node" in element:
+                            arg[i] = resolve_from_node(process_graph, node, element['from_node'])
 
         if result_node is None:
             raise ValueError("The provided process graph does not contain a result node.")
         return result_node
+
 
     def accept_process_graph(self,graph:Dict):
         """
@@ -52,7 +59,7 @@ class ProcessGraphVisitor(ABC):
         :param graph:
         :return:
         """
-        top_level_node = ProcessGraphVisitor._list_to_graph(graph)
+        top_level_node = self.dereference_from_node_arguments(graph)
         self.accept(graph[top_level_node])
         return self
 

--- a/tests/test_GraphVisitor.py
+++ b/tests/test_GraphVisitor.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
-from unittest.mock import MagicMock,call,ANY
+from unittest.mock import MagicMock, call, ANY
+
+import pytest
 
 from openeo.internal.process_graph_visitor import ProcessGraphVisitor
 
@@ -100,3 +102,99 @@ class GraphVisitorTest(TestCase):
         ])
 
         print(leaveProcess)
+
+
+def test_dereference_basic():
+    graph = {
+        "node1": {},
+        "node2": {
+            "arguments": {
+                "data1": {
+                    "from_node": "node1"
+                },
+                "data2": {
+                    "from_node": "node3"
+                }
+            },
+            "result": True
+        },
+        "node3": {
+            "arguments": {
+                "data": {
+                    "from_node": "node4"
+                }
+            }
+        },
+        "node4": {}
+    }
+    result = ProcessGraphVisitor.dereference_from_node_arguments(graph)
+
+    assert result == "node2"
+    assert graph["node1"] == graph["node2"]["arguments"]["data1"]["node"]
+    assert graph["node3"] == graph["node2"]["arguments"]["data2"]["node"]
+    assert graph["node4"] == graph["node3"]["arguments"]["data"]["node"]
+    assert graph == {
+        "node1": {},
+        "node2": {
+            "arguments": {
+                "data1": {"from_node": "node1", "node": {}},
+                "data2": {"from_node": "node3", "node": {
+                    "arguments": {
+                        "data": {"from_node": "node4", "node": {}},
+                    }
+                }},
+            },
+            "result": True
+        },
+        "node3": {
+            "arguments": {
+                "data": {"from_node": "node4", "node": {}},
+            }
+        },
+        "node4": {}
+
+    }
+
+
+def test_dereference_no_result_node():
+    with pytest.raises(ValueError, match="does not contain a result node"):
+        ProcessGraphVisitor.dereference_from_node_arguments({
+            "node1": {},
+            "node2": {}
+        })
+
+
+def test_dereference_invalid_node():
+    graph = {
+        "node1": {},
+        "node2": {
+            "arguments": {
+                "data": {
+                    "from_node": "node3"
+                }
+            },
+            "result": True
+        }
+    }
+    with pytest.raises(ValueError, match="not in process graph"):
+        ProcessGraphVisitor.dereference_from_node_arguments(graph)
+
+
+def test_dereference_cycle():
+    graph = {
+        "node1": {
+            "arguments": {
+                "data": {"from_node": "node2"},
+            },
+            "result": True
+        },
+        "node2": {
+            "arguments": {
+                "data": {"from_node": "node1"},
+            }
+        }
+    }
+    ProcessGraphVisitor.dereference_from_node_arguments(graph)
+    assert graph["node1"]["arguments"]["data"]["node"] is graph["node2"]
+    assert graph["node2"]["arguments"]["data"]["node"] is graph["node1"]
+


### PR DESCRIPTION
`ProcessGraphVisitor._list_to_graph`:
- simplify logic
- Improve docblock and function name (deprecate old name)
- move related tests from openeo-python-driver