### PR TITLE
Issue #65: openeo.client_version() returns client version

### DIFF
--- a/openeo/__init__.py
+++ b/openeo/__init__.py
@@ -13,7 +13,7 @@ This client allows users to communicate with OpenEO backends, in a way that feel
 __title__ = 'openeo'
 __author__ = 'Jeroen Dries'
 
-from ._version import __version__
+from openeo._version import __version__
 from openeo.catalog import EOProduct
 from openeo.imagecollection import ImageCollection
 from openeo.rest.rest_connection import connection as connect
@@ -23,10 +23,5 @@ from openeo.auth.auth import Auth
 from openeo.process.process import *
 
 
-# TODO: why is this a constant? Shouldn't the client be capable of working with (a range of) multiple versions?
-# TODO: make some kind of config file for the client version
-CLIENT_VERSION = "0.3.0"
-
-
-def version():
-    return CLIENT_VERSION
+def client_version():
+    return __version__


### PR DESCRIPTION
client version has nothing to do with openEO API version

this PR avoids the confusion (see #65 )