### PR TITLE
Better deprecation of old style date_range_filter and bbox_filter

### DIFF
--- a/examples/eodc_example.py
+++ b/examples/eodc_example.py
@@ -22,8 +22,8 @@ session = openeo.connect(EODC_DRIVER_URL,auth_type=BearerAuth, auth_options={"us
 s2a_prd_msil1c = session.image("s2a_prd_msil1c")
 logging.debug("{}".format(s2a_prd_msil1c.graph))
 
-timeseries = s2a_prd_msil1c.bbox_filter(left=652000, right=672000, top=5161000,
-                                              bottom=5181000, srs="EPSG:32632")
+timeseries = s2a_prd_msil1c.filter_bbox(west=652000, east=672000, north=5161000,
+                                              south=5181000, crs="EPSG:32632")
 logging.debug("{}".format(timeseries.graph))
 
 timeseries = timeseries.filter_temporal("2017-01-01", "2017-01-08")

--- a/examples/eodc_example.py
+++ b/examples/eodc_example.py
@@ -26,7 +26,7 @@ timeseries = s2a_prd_msil1c.bbox_filter(left=652000, right=672000, top=5161000,
                                               bottom=5181000, srs="EPSG:32632")
 logging.debug("{}".format(timeseries.graph))
 
-timeseries = timeseries.date_range_filter("2017-01-01", "2017-01-08")
+timeseries = timeseries.filter_temporal("2017-01-01", "2017-01-08")
 logging.debug("{}".format(timeseries.graph))
 
 timeseries = timeseries.ndvi("B04", "B08")

--- a/examples/notebooks/Compositing.ipynb
+++ b/examples/notebooks/Compositing.ipynb
@@ -106,7 +106,7 @@
    "source": [
     "#.bbox_filter(left=4.3,right=5.0,top=50.55,bottom=50.28,srs=\"EPSG:4326\")\n",
     "timeseries = s2_radiometry\\\n",
-    ".date_range_filter(\"2017-10-14\",\"2017-10-17\")\\\n",
+    ".filter_temporal(\"2017-10-14\",\"2017-10-17\")\\\n",
     ".bbox_filter(left=761104,right=763281,bottom=6543830,top=6544655,srs=\"EPSG:3857\")\n",
     "timeseries"
    ]

--- a/examples/notebooks/Compositing.ipynb
+++ b/examples/notebooks/Compositing.ipynb
@@ -104,10 +104,9 @@
     }
    ],
    "source": [
-    "#.bbox_filter(left=4.3,right=5.0,top=50.55,bottom=50.28,srs=\"EPSG:4326\")\n",
     "timeseries = s2_radiometry\\\n",
     ".filter_temporal(\"2017-10-14\",\"2017-10-17\")\\\n",
-    ".bbox_filter(left=761104,right=763281,bottom=6543830,top=6544655,srs=\"EPSG:3857\")\n",
+    ".filter_bbox(west=761104,east=763281,south=6543830,north=6544655,crs=\"EPSG:3857\")\n",
     "timeseries"
    ]
   },

--- a/examples/notebooks/PoC_EODC.ipynb
+++ b/examples/notebooks/PoC_EODC.ipynb
@@ -241,7 +241,7 @@
     "# Specifying the date range and the bounding box\n",
     "timeseries = s2a_prd_msil1c.bbox_filter(left=IMAGE_LEFT, right=IMAGE_RIGHT, top=IMAGE_TOP,\n",
     "                                             bottom=IMAGE_BOTTOM, srs=IMAGE_SRS)\n",
-    "timeseries = timeseries.date_range_filter(DATE_START, DATE_END)\n",
+    "timeseries = timeseries.filter_temporal(DATE_START, DATE_END)\n",
     "\n",
     "timeseries"
    ]

--- a/examples/notebooks/PoC_EODC.ipynb
+++ b/examples/notebooks/PoC_EODC.ipynb
@@ -239,8 +239,8 @@
    ],
    "source": [
     "# Specifying the date range and the bounding box\n",
-    "timeseries = s2a_prd_msil1c.bbox_filter(left=IMAGE_LEFT, right=IMAGE_RIGHT, top=IMAGE_TOP,\n",
-    "                                             bottom=IMAGE_BOTTOM, srs=IMAGE_SRS)\n",
+    "timeseries = s2a_prd_msil1c.filter_bbox(west=IMAGE_LEFT, east=IMAGE_RIGHT, north=IMAGE_TOP,\n",
+    "                                             south=IMAGE_BOTTOM, crs=IMAGE_SRS)\n",
     "timeseries = timeseries.filter_temporal(DATE_START, DATE_END)\n",
     "\n",
     "timeseries"

--- a/examples/notebooks/PoC_EURAC.ipynb
+++ b/examples/notebooks/PoC_EURAC.ipynb
@@ -128,7 +128,7 @@
    "source": [
     "# Specifying the date range and the bounding box\n",
     "download = s2_fapar \\\n",
-    "    .bbox_filter(left=IMAGE_LEFT, right=IMAGE_RIGHT, top=IMAGE_TOP, bottom=IMAGE_BOTTOM,srs=IMAGE_SRS) \\\n",
+    "    .filter_bbox(west=IMAGE_LEFT, east=IMAGE_RIGHT, north=IMAGE_TOP, south=IMAGE_BOTTOM,crs=IMAGE_SRS) \\\n",
     "    .filter_temporal(DATE_START, DATE_END) \\\n",
     "    .ndvi(NDVI_RED, NDVI_NIR) \\\n",
     "    .max_time() \\\n",

--- a/examples/notebooks/PoC_EURAC.ipynb
+++ b/examples/notebooks/PoC_EURAC.ipynb
@@ -129,7 +129,7 @@
     "# Specifying the date range and the bounding box\n",
     "download = s2_fapar \\\n",
     "    .bbox_filter(left=IMAGE_LEFT, right=IMAGE_RIGHT, top=IMAGE_TOP, bottom=IMAGE_BOTTOM,srs=IMAGE_SRS) \\\n",
-    "    .date_range_filter(DATE_START, DATE_END) \\\n",
+    "    .filter_temporal(DATE_START, DATE_END) \\\n",
     "    .ndvi(NDVI_RED, NDVI_NIR) \\\n",
     "    .max_time() \\\n",
     "    .download(OUTPUT_FILE,format=OUTFORMAT)\n",

--- a/examples/notebooks/PoC_GEE_UsingProcess.ipynb
+++ b/examples/notebooks/PoC_GEE_UsingProcess.ipynb
@@ -264,7 +264,7 @@
     "# Specifying the date range and the bounding box\n",
     "timeseries = openeo.bbox_filter(coperincus_s2_image, left=IMAGE_LEFT, right=IMAGE_RIGHT, top=IMAGE_TOP,\n",
     "                                             bottom=IMAGE_BOTTOM, srs=IMAGE_SRS)\n",
-    "timeseries = openeo.date_range_filter(timeseries, DATE_START, DATE_END)\n",
+    "timeseries = openeo.filter_temporal(timeseries, DATE_START, DATE_END)\n",
     "\n",
     "timeseries"
    ]

--- a/examples/notebooks/PoC_GEE_UsingProcess.ipynb
+++ b/examples/notebooks/PoC_GEE_UsingProcess.ipynb
@@ -262,8 +262,8 @@
    ],
    "source": [
     "# Specifying the date range and the bounding box\n",
-    "timeseries = openeo.bbox_filter(coperincus_s2_image, left=IMAGE_LEFT, right=IMAGE_RIGHT, top=IMAGE_TOP,\n",
-    "                                             bottom=IMAGE_BOTTOM, srs=IMAGE_SRS)\n",
+    "timeseries = openeo.filter_bbox(coperincus_s2_image, west=IMAGE_LEFT, east=IMAGE_RIGHT, north=IMAGE_TOP,\n",
+    "                                             south=IMAGE_BOTTOM, crs=IMAGE_SRS)\n",
     "timeseries = openeo.filter_temporal(timeseries, DATE_START, DATE_END)\n",
     "\n",
     "timeseries"

--- a/examples/phenology_example.py
+++ b/examples/phenology_example.py
@@ -29,7 +29,7 @@ print(collections)
 
 """
 cloud_mask = session.image("S2_SCENECLASSIFICATION") \
-    .date_range_filter("2017-03-01","2017-02-20") \
+    .filter_temporal("2017-03-01","2017-02-20") \
     .bbox_filter(left=652000,right=672000,top=5161000,bottom=5181000,srs="EPSG:32632") \
     .apply_pixel(map_classification_to_binary)
 """
@@ -61,7 +61,7 @@ minx,miny,maxx,maxy = polygon.bounds
 #compute EVI
 #https://en.wikipedia.org/wiki/Enhanced_vegetation_index
 s2_radiometry = session.imagecollection("CGS_SENTINEL2_RADIOMETRY_V102_001") \
-                    .date_range_filter("2017-01-01","2017-10-01") #\
+                    .filter_temporal("2017-01-01","2017-10-01") #\
                    # .bbox_filter(left=minx,right=maxx,top=maxy,bottom=miny,srs="EPSG:4326")
 
 B02 = s2_radiometry.band('2')

--- a/examples/phenology_example.py
+++ b/examples/phenology_example.py
@@ -30,7 +30,7 @@ print(collections)
 """
 cloud_mask = session.image("S2_SCENECLASSIFICATION") \
     .filter_temporal("2017-03-01","2017-02-20") \
-    .bbox_filter(left=652000,right=672000,top=5161000,bottom=5181000,srs="EPSG:32632") \
+    .filter_bbox(west=652000,east=672000,north=5161000,south=5181000,crs="EPSG:32632") \
     .apply_pixel(map_classification_to_binary)
 """
 
@@ -62,7 +62,7 @@ minx,miny,maxx,maxy = polygon.bounds
 #https://en.wikipedia.org/wiki/Enhanced_vegetation_index
 s2_radiometry = session.imagecollection("CGS_SENTINEL2_RADIOMETRY_V102_001") \
                     .filter_temporal("2017-01-01","2017-10-01") #\
-                   # .bbox_filter(left=minx,right=maxx,top=maxy,bottom=miny,srs="EPSG:4326")
+                   # .filter_bbox(west=minx,east=maxx,north=maxy,south=miny,crs="EPSG:4326")
 
 B02 = s2_radiometry.band('2')
 B04 = s2_radiometry.band('4')

--- a/openeo/imagecollection.py
+++ b/openeo/imagecollection.py
@@ -1,9 +1,12 @@
 from abc import ABC
+from datetime import datetime, date
 from typing import List, Dict, Union
-from datetime import datetime,date
+
+from deprecated import deprecated
+from shapely.geometry import Polygon, MultiPolygon
 
 from openeo.job import Job
-from shapely.geometry import Polygon, MultiPolygon
+from openeo.util import get_temporal_extent
 
 
 class ImageCollection(ABC):
@@ -12,6 +15,7 @@ class ImageCollection(ABC):
     def __init__(self):
         pass
 
+    @deprecated("Use `filter_temporal()` instead")
     def date_range_filter(self, start_date:Union[str,datetime,date],end_date:Union[str,datetime,date]) -> 'ImageCollection':
         """
         Specifies a date range filter to be applied on the ImageCollection
@@ -21,8 +25,9 @@ class ImageCollection(ABC):
         :param end_date: End date of the filter, exclusive, format e.g.: "2018-01-13".
         :return: An ImageCollection filtered by date.
         """
-        pass
+        return self.filter_temporal(start_date=start_date, end_date=end_date)
 
+    @deprecated("Use `filter_temporal()` instead")
     def filter_daterange(self, extent) -> 'ImageCollection':
         """Drops observations from a collection that have been captured before
             a start or after a given end date.
@@ -30,11 +35,38 @@ class ImageCollection(ABC):
             :param extent: List of starting date and ending date of the filter
             :return: An ImageCollection filtered by date.
         """
-        if len(extent) == 0:
-            raise ValueError("extent should contain 2 elements, but got empty list: " + extent)
-        start = extent[0]
-        end = extent[1] if len(extent) >1 else None
-        return self.date_range_filter(start,end)
+        return self.filter_temporal(extent=extent)
+
+    def filter_temporal(self, *args,
+                        start_date: Union[str, datetime, date] = None, end_date: Union[str, datetime, date] = None,
+                        extent: Union[list, tuple] = None) -> 'ImageCollection':
+        """
+        Limit the ImageCollection to a certain date range, which can be specified in several ways:
+
+        >>> im.filter_temporal("2019-07-01", "2019-08-01")
+        >>> im.filter_temporal(["2019-07-01", "2019-08-01"])
+        >>> im.filter_temporal(extent=["2019-07-01", "2019-08-01"])
+        >>> im.filter_temporal(start_date="2019-07-01", end_date="2019-08-01"])
+
+        :param start_date: start date of the filter (inclusive), as a string or date object
+        :param end_date: end date of the filter (exclusive), as a string or date object
+        :param extent: two element list/tuple start and end date of the filter
+        :return: An ImageCollection filtered by date.
+
+        Subclasses are recommended to implement `_filter_temporal', which has simpler API.
+
+        https://open-eo.github.io/openeo-api/processreference/#filter_temporal
+        """
+        start, end = get_temporal_extent(*args, start_date=start_date, end_date=end_date, extent=extent)
+        return self._filter_temporal(start, end)
+
+    def _filter_temporal(self, start_date: str, end_date: str) -> 'ImageCollection':
+        # Subclasses are expected to implement this method, but for bit of backward compatibility
+        # with old style subclasses we forward to `date_range_filter`
+        # TODO: replace this with raise NotImplementedError() or decorate with @abstractmethod
+        return self.date_range_filter(start_date, end_date)
+
+
 
     def filter_bbox(self, west, east, north, south, crs=None, base=None, height=None) -> 'ImageCollection':
         """Drops observations from a collection that are located outside

--- a/openeo/process/process.py
+++ b/openeo/process/process.py
@@ -30,20 +30,20 @@ def filter_temporal(imagecollection, start_date: Union[str, datetime, date], end
     return imagecollection.filter_temporal(start_date, end_date)
 
 
-def bbox_filter(imagecollection, left: float, right: float, top: float, bottom: float, srs: str) -> 'ImageCollection':
+def filter_bbox(imagecollection, west: float, east: float, north: float, south: float, crs: str) -> 'ImageCollection':
     """
     Specifies a bounding box to filter input image collections.
 
     :param imagecollection: Image collection to apply the process, Instance of ImageCollection
-    :param left:
-    :param right:
-    :param top:
-    :param bottom:
-    :param srs:
+    :param west:
+    :param east:
+    :param north:
+    :param south:
+    :param crs:
 
     :return: An image collection cropped to the specified bounding box.
     """
-    return imagecollection.bbox_filter(left, right, top, bottom, srs)
+    return imagecollection.filter_bbox(west=west, east=east, north=north, south=south, crs=crs)
 
 
 def apply_pixel(imagecollection, bands: List, bandfunction) -> 'ImageCollection':

--- a/openeo/process/process.py
+++ b/openeo/process/process.py
@@ -3,6 +3,7 @@
 from typing import List, Union
 from datetime import datetime, date
 
+# TODO is this module (still) useful? also see https://github.com/Open-EO/openeo-python-client/issues/61
 
 def ndvi(imagecollection, red, nir):
     """ NDVI
@@ -16,7 +17,7 @@ def ndvi(imagecollection, red, nir):
     return imagecollection.ndvi(red, nir)
 
 
-def date_range_filter(imagecollection, start_date: Union[str, datetime, date], end_date: Union[str, datetime, date]) -> 'ImageCollection':
+def filter_temporal(imagecollection, start_date: Union[str, datetime, date], end_date: Union[str, datetime, date]) -> 'ImageCollection':
     """
     Specifies a date range filter to be applied on the ImageCollection
 
@@ -26,7 +27,7 @@ def date_range_filter(imagecollection, start_date: Union[str, datetime, date], e
 
     :return: An ImageCollection filtered by date.
     """
-    return imagecollection.date_range_filter(start_date, end_date)
+    return imagecollection.filter_temporal(start_date, end_date)
 
 
 def bbox_filter(imagecollection, left: float, right: float, top: float, bottom: float, srs: str) -> 'ImageCollection':

--- a/openeo/rest/imagecollectionclient.py
+++ b/openeo/rest/imagecollectionclient.py
@@ -75,31 +75,20 @@ class ImageCollectionClient(ImageCollection):
             }
         )
 
-    def bbox_filter(self, west=None, east=None, north=None, south=None, crs=None,left=None, right=None, top=None, bottom=None, srs=None) -> 'ImageCollection':
-        """Drops observations from a collection that are located outside
-            of a given bounding box.
-
-            :param east: east boundary (longitude / easting)
-            :param west: west boundary (longitude / easting)
-            :param north: north boundary (latitude / northing)
-            :param south: south boundary (latitude / northing)
-            :param srs: coordinate reference system of boundaries as
-                        proj4 or EPSG:12345 like string
-            :return: An ImageCollection instance
-        """
-
-        process_id = 'filter_bbox'
-        args = {
+    def filter_bbox(self, west, east, north, south, crs=None, base=None, height=None) -> 'ImageCollection':
+        extent = {
+            'west': west, 'east': east, 'north': north, 'south': south,
+            'crs': crs,
+        }
+        if base is not None or height is not None:
+            extent.update(base=base, height=height)
+        return self.graph_add_process(
+            process_id='filter_bbox',
+            args={
                 'data': {'from_node': self.node_id},
-                'extent': {
-                    'west': first_not_none(west, left),
-                    'east': first_not_none(east, right),
-                    'north': first_not_none(north, top),
-                    'south': first_not_none(south, bottom),
-                    'crs': first_not_none(crs, srs)
-                }
+                'extent': extent
             }
-        return self.graph_add_process(process_id, args)
+        )
 
     def band_filter(self, bands) -> 'ImageCollection':
         """Filter the imagery by the given bands

--- a/openeo/rest/imagecollectionclient.py
+++ b/openeo/rest/imagecollectionclient.py
@@ -66,23 +66,14 @@ class ImageCollectionClient(ImageCollection):
         id = builder.process(process_id, arguments)
         return ImageCollectionClient(id, builder, session)
 
-    def date_range_filter(self, start_date: Union[str, datetime, date],
-                          end_date: Union[str, datetime, date]) -> 'ImageCollection':
-        """Drops observations from a collection that have been captured before
-            a start or after a given end date.
-
-            :param start_date: starting date of the filter
-            :param end_date: ending date of the filter
-            :return: An ImageCollection instance
-        """
-        process_id = 'filter_temporal'
-
-        args = {
-            'data':{'from_node': self.node_id},
-            'extent': [start_date, end_date]
-        }
-
-        return self.graph_add_process(process_id, args)
+    def _filter_temporal(self, start: str, end: str) -> 'ImageCollection':
+        return self.graph_add_process(
+            process_id='filter_temporal',
+            args={
+                'data': {'from_node': self.node_id},
+                'extent': [start, end]
+            }
+        )
 
     def bbox_filter(self, west=None, east=None, north=None, south=None, crs=None,left=None, right=None, top=None, bottom=None, srs=None) -> 'ImageCollection':
         """Drops observations from a collection that are located outside

--- a/openeo/rest/imagery.py
+++ b/openeo/rest/imagery.py
@@ -22,8 +22,7 @@ class RestImagery(ImageCollection):
         self.graph = parentgraph
         self.session = session
 
-    def date_range_filter(self, start_date: Union[str, datetime, date],
-                          end_date: Union[str, datetime, date]) -> 'ImageCollection':
+    def _filter_temporal(self, start_date: str, end_date: str) -> 'ImageCollection':
         """Drops observations from a collection that have been captured before
             a start or after a given end date.
             :param start_date: starting date of the filter

--- a/openeo/rest/imagery.py
+++ b/openeo/rest/imagery.py
@@ -2,15 +2,13 @@ import base64
 from typing import List, Dict, Union
 
 import cloudpickle
-from datetime import datetime, date
 from pandas import Series
+from shapely.geometry import Polygon, MultiPolygon, mapping
 
+from openeo.connection import Connection
+from openeo.imagecollection import ImageCollection
 from openeo.job import Job
 from openeo.rest.job import RESTJob
-from openeo.imagecollection import ImageCollection
-from openeo.util import first_not_none
-from openeo.connection import Connection
-from shapely.geometry import Polygon, MultiPolygon, mapping
 
 
 class RestImagery(ImageCollection):
@@ -37,7 +35,7 @@ class RestImagery(ImageCollection):
 
         return self.graph_add_process(process_id, args)
 
-    def bbox_filter(self, west=None, east=None, north=None, south=None, crs=None,left=None, right=None, top=None, bottom=None, srs=None) -> 'ImageCollection':
+    def filter_bbox(self, west, east, north, south, crs=None, base=None, height=None) -> 'ImageCollection':
         """Drops observations from a collection that are located outside
             of a given bounding box.
             :param left: left boundary (longitude / easting)
@@ -50,16 +48,13 @@ class RestImagery(ImageCollection):
         """
         process_id = 'filter_bbox'
         args = {
-                'imagery': self.graph,
-                'extent':
+            'imagery': self.graph,
+            'extent':
                 {
-                    'west': first_not_none(west, left),
-                    'east': first_not_none(east, right),
-                    'north': first_not_none(north, top),
-                    'south': first_not_none(south, bottom),
-                    'crs': first_not_none(crs, srs),
+                    'west': west, 'east': east, 'north': north, 'south': south,
+                    'crs': crs,
                 }
-            }
+        }
         return self.graph_add_process(process_id, args)
 
     def band_filter(self, bands) -> 'ImageCollection':

--- a/openeo/util.py
+++ b/openeo/util.py
@@ -2,19 +2,24 @@
 Various utilities and helpers.
 """
 import re
-from datetime import datetime
+from datetime import datetime, date
 from typing import Any, Union, Tuple
 
 _rfc3339_date_format = re.compile(r'\d{4}-\d{2}-\d{2}')
 
 
-def date_to_rfc3339(date: Any) -> str:
+def date_to_rfc3339(d: Any) -> str:
     """
     Convert date-like object to a RFC 3339 formatted date string
     """
-    if isinstance(date, str):
-        if _rfc3339_date_format.match(date):
-            return date
+    if isinstance(d, str):
+        if _rfc3339_date_format.match(d):
+            return d
+    elif isinstance(d, datetime):
+        assert d.tzinfo is None, "timezone handling not supported (TODO)"
+        return d.strftime('%Y-%m-%dT%H:%M:%SZ')
+    elif isinstance(d, date):
+        return d.strftime('%Y-%m-%d')
     raise NotImplementedError("TODO")
 
 
@@ -27,7 +32,7 @@ def first_not_none(*args):
 
 
 def get_temporal_extent(*args,
-                        start_date: Union[str, datetime] = None, end_date: Union[str, datetime] = None,
+                        start_date: Union[str, datetime, date] = None, end_date: Union[str, datetime, date] = None,
                         extent: Union[list, tuple] = None,
                         convertor=date_to_rfc3339
                         ) -> Tuple[Union[str, None], Union[str, None]]:

--- a/openeo/util.py
+++ b/openeo/util.py
@@ -1,6 +1,21 @@
 """
 Various utilities and helpers.
 """
+import re
+from datetime import datetime
+from typing import Any, Union, Tuple
+
+_rfc3339_date_format = re.compile(r'\d{4}-\d{2}-\d{2}')
+
+
+def date_to_rfc3339(date: Any) -> str:
+    """
+    Convert date-like object to a RFC 3339 formatted date string
+    """
+    if isinstance(date, str):
+        if _rfc3339_date_format.match(date):
+            return date
+    raise NotImplementedError("TODO")
 
 
 def first_not_none(*args):
@@ -9,3 +24,40 @@ def first_not_none(*args):
         if item is not None:
             return item
     raise ValueError("No not-None values given.")
+
+
+def get_temporal_extent(*args,
+                        start_date: Union[str, datetime] = None, end_date: Union[str, datetime] = None,
+                        extent: Union[list, tuple] = None,
+                        convertor=date_to_rfc3339
+                        ) -> Tuple[Union[str, None], Union[str, None]]:
+    """
+    Helper to derive a date extent from from various call forms:
+
+        >>> get_temporal_extent("2019-01-01")
+        ("2019-01-01", None)
+        >>> get_temporal_extent("2019-01-01", "2019-05-15")
+        ("2019-01-01", "2019-05-15")
+        >>> get_temporal_extent(["2019-01-01", "2019-05-15"])
+        ("2019-01-01", "2019-05-15")
+        >>> get_temporal_extent(start_date="2019-01-01", end_date="2019-05-15"])
+        ("2019-01-01", "2019-05-15")
+        >>> get_temporal_extent(extent=["2019-01-01", "2019-05-15"])
+        ("2019-01-01", "2019-05-15")
+    """
+    if args:
+        assert start_date is None and end_date is None and extent is None
+        if len(args) == 2:
+            start_date, end_date = args
+        elif len(args) == 1:
+            arg = args[0]
+            if isinstance(arg, (list, tuple)):
+                start_date, end_date = arg
+            else:
+                start_date, end_date = arg, None
+        else:
+            raise ValueError('Unable to handle {a!r} as a date range'.format(a=args))
+    elif extent:
+        assert start_date is None and end_date is None
+        start_date, end_date = extent
+    return convertor(start_date) if start_date else None, convertor(end_date) if end_date else None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ cloudpickle
 numpy
 pandas
 requests-mock
+deprecated

--- a/tests/test_imagery.py
+++ b/tests/test_imagery.py
@@ -1,5 +1,5 @@
-import unittest
 from unittest import TestCase
+
 from openeo.rest.imagery import RestImagery
 
 
@@ -18,47 +18,45 @@ class TestImagery(TestCase):
         graph = new_imagery.graph
         assert graph == {'process_id': 'filter_daterange', 'imagery': {}, 'extent': ["2016-01-01", "2016-03-10"]}
 
+    def test_filter_bbox(self):
+        im = self.processes.filter_bbox(
+            west=652000, east=672000, north=5161000, south=5181000, crs="EPSG:32632"
+        )
+        assert im.graph == {
+            "process_id": "filter_bbox",
+            "imagery": {},
+            "extent": {"west": 652000, "east": 672000, "north": 5161000, "south": 5181000, "crs": "EPSG:32632"}
+        }
+
     def test_bbox_filter_nsew(self):
         new_imagery = self.processes.bbox_filter(
             west=652000, east=672000, north=5161000, south=5181000, crs="EPSG:32632"
         )
-        graph = new_imagery.graph
-
-        self.assertEqual(graph["process_id"], "filter_bbox")
-        self.assertEqual(graph["imagery"], {})
-        self.assertEqual(graph["extent"]["west"], 652000)
-        self.assertEqual(graph["extent"]["east"], 672000)
-        self.assertEqual(graph["extent"]["north"], 5161000)
-        self.assertEqual(graph["extent"]["south"], 5181000)
-        self.assertEqual(graph["extent"]["crs"], "EPSG:32632")
+        assert new_imagery.graph == {
+            "process_id": "filter_bbox",
+            "imagery": {},
+            "extent": {"west": 652000, "east": 672000, "north": 5161000, "south": 5181000, "crs": "EPSG:32632"}
+        }
 
     def test_bbox_filter_tblr(self):
         new_imagery = self.processes.bbox_filter(
             left=652000, right=672000, top=5161000, bottom=5181000, srs="EPSG:32632"
         )
-        graph = new_imagery.graph
-
-        self.assertEqual(graph["process_id"], "filter_bbox")
-        self.assertEqual(graph["imagery"], {})
-        self.assertEqual(graph["extent"]["west"], 652000)
-        self.assertEqual(graph["extent"]["east"], 672000)
-        self.assertEqual(graph["extent"]["north"], 5161000)
-        self.assertEqual(graph["extent"]["south"], 5181000)
-        self.assertEqual(graph["extent"]["crs"], "EPSG:32632")
+        assert new_imagery.graph == {
+            "process_id": "filter_bbox",
+            "imagery": {},
+            "extent": {"west": 652000, "east": 672000, "north": 5161000, "south": 5181000, "crs": "EPSG:32632"}
+        }
 
     def test_bbox_filter_nsew_zero(self):
         new_imagery = self.processes.bbox_filter(
             north=0, south=0, east=0, west=0, srs="EPSG:32632"
         )
-        graph = new_imagery.graph
-
-        self.assertEqual(graph["process_id"], "filter_bbox")
-        self.assertEqual(graph["imagery"], {})
-        self.assertEqual(graph["extent"]["west"], 0)
-        self.assertEqual(graph["extent"]["east"], 0)
-        self.assertEqual(graph["extent"]["north"], 0)
-        self.assertEqual(graph["extent"]["south"], 0)
-        self.assertEqual(graph["extent"]["crs"], "EPSG:32632")
+        assert new_imagery.graph == {
+            "process_id": "filter_bbox",
+            "imagery": {},
+            "extent": {"west": 0, "east": 0, "north": 0, "south": 0, "crs": "EPSG:32632"}
+        }
 
     def test_apply_pixel(self):
         bandFunction = lambda cells,nodata: (cells[3]-cells[2])/(cells[3]+cells[2])

--- a/tests/test_imagery.py
+++ b/tests/test_imagery.py
@@ -10,13 +10,13 @@ class TestImagery(TestCase):
 
     def test_date_range_filter(self):
         new_imagery = self.processes.date_range_filter("2016-01-01", "2016-03-10")
-
         graph = new_imagery.graph
+        assert graph == {'process_id': 'filter_daterange', 'imagery': {}, 'extent': ["2016-01-01", "2016-03-10"]}
 
-        self.assertEqual(graph["process_id"],"filter_daterange")
-        self.assertEqual(graph["imagery"], {})
-        self.assertEqual(graph["extent"][0], "2016-01-01")
-        self.assertEqual(graph["extent"][1], "2016-03-10")
+    def test_filter_temporal(self):
+        new_imagery = self.processes.filter_temporal("2016-01-01", "2016-03-10")
+        graph = new_imagery.graph
+        assert graph == {'process_id': 'filter_daterange', 'imagery': {}, 'extent': ["2016-01-01", "2016-03-10"]}
 
     def test_bbox_filter_nsew(self):
         new_imagery = self.processes.bbox_filter(

--- a/tests/test_rastercube.py
+++ b/tests/test_rastercube.py
@@ -1,11 +1,90 @@
+from datetime import date, datetime
 from unittest import TestCase
+
+import numpy as np
+import pytest
+from mock import MagicMock, patch
 
 from openeo.capabilities import Capabilities
 from openeo.connection import Connection
-from openeo.rest.imagecollectionclient import ImageCollectionClient
 from openeo.graphbuilder import GraphBuilder
-from mock import MagicMock, patch
-import numpy as np
+from openeo.rest.imagecollectionclient import ImageCollectionClient
+
+
+@pytest.fixture
+def image_collection():
+    builder = GraphBuilder()
+    id = builder.process("get_collection", {'name': 'S1'})
+
+    connection = MagicMock(spec=Connection)
+    capabilities = MagicMock(spec=Capabilities)
+
+    connection.capabilities.return_value = capabilities
+    capabilities.version.return_value = "0.4.0"
+    return ImageCollectionClient(id, builder, connection)
+
+
+def test_date_range_filter(image_collection: ImageCollectionClient):
+    im = image_collection.date_range_filter("2016-01-01", "2016-03-10")
+    graph = im.graph[im.node_id]
+    assert graph['process_id'] == 'filter_temporal'
+    assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
+
+
+def test_filter_daterange(image_collection: ImageCollectionClient):
+    im = image_collection.filter_daterange(extent=("2016-01-01", "2016-03-10"))
+    graph = im.graph[im.node_id]
+    assert graph['process_id'] == 'filter_temporal'
+    assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
+
+
+def test_filter_temporal(image_collection: ImageCollectionClient):
+    im = image_collection.filter_temporal("2016-01-01", "2016-03-10")
+    graph = im.graph[im.node_id]
+    assert graph['process_id'] == 'filter_temporal'
+    assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
+
+
+def test_filter_temporal_start_end(image_collection: ImageCollectionClient):
+    im = image_collection.filter_temporal(start_date="2016-01-01", end_date="2016-03-10")
+    graph = im.graph[im.node_id]
+    assert graph['process_id'] == 'filter_temporal'
+    assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
+
+
+def test_filter_temporal_extent(image_collection: ImageCollectionClient):
+    im = image_collection.filter_temporal(extent=("2016-01-01", "2016-03-10"))
+    graph = im.graph[im.node_id]
+    assert graph['process_id'] == 'filter_temporal'
+    assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
+
+
+@pytest.mark.parametrize("args,kwargs,extent", [
+    ((), {}, [None, None]),
+    (("2016-01-01",), {}, ["2016-01-01", None]),
+    (("2016-01-01", "2016-03-10"), {}, ["2016-01-01", "2016-03-10"]),
+    ((date(2016, 1, 1), date(2016, 3, 10)), {}, ["2016-01-01", "2016-03-10"]),
+    ((datetime(2016, 1, 1, 12, 34), datetime(2016, 3, 10, 23, 45)), {},
+     ["2016-01-01T12:34:00Z", "2016-03-10T23:45:00Z"]),
+    ((), {"start_date": "2016-01-01", "end_date": "2016-03-10"}, ["2016-01-01", "2016-03-10"]),
+    ((), {"start_date": "2016-01-01"}, ["2016-01-01", None]),
+    ((), {"end_date": "2016-03-10"}, [None, "2016-03-10"]),
+    ((), {"start_date": date(2016, 1, 1), "end_date": date(2016, 3, 10)}, ["2016-01-01", "2016-03-10"]),
+    ((), {"start_date": datetime(2016, 1, 1, 12, 34), "end_date": datetime(2016, 3, 10, 23, 45)},
+     ["2016-01-01T12:34:00Z", "2016-03-10T23:45:00Z"]),
+    ((), {"extent": ("2016-01-01", "2016-03-10")}, ["2016-01-01", "2016-03-10"]),
+    ((), {"extent": ("2016-01-01", None)}, ["2016-01-01", None]),
+    ((), {"extent": (None, "2016-03-10")}, [None, "2016-03-10"]),
+    ((), {"extent": (date(2016, 1, 1), date(2016, 3, 10))}, ["2016-01-01", "2016-03-10"]),
+    ((), {"extent": (datetime(2016, 1, 1, 12, 34), datetime(2016, 3, 10, 23, 45))},
+     ["2016-01-01T12:34:00Z", "2016-03-10T23:45:00Z"]),
+])
+def test_filter_temporal_generic(image_collection: ImageCollectionClient, args, kwargs, extent):
+    im = image_collection.filter_temporal(*args, **kwargs)
+    graph = im.graph[im.node_id]
+    assert graph['process_id'] == 'filter_temporal'
+    assert graph['arguments']['extent'] == extent
+
 
 class TestRasterCube(TestCase):
 
@@ -24,36 +103,6 @@ class TestRasterCube(TestCase):
         builder = GraphBuilder()
         mask_id = builder.process("get_collection", {'name': 'S1_Mask'})
         self.mask = ImageCollectionClient(mask_id, builder, connection)
-
-    def test_date_range_filter(self):
-        im = self.imagery.date_range_filter("2016-01-01", "2016-03-10")
-        graph = im.graph[im.node_id]
-        assert graph['process_id'] == 'filter_temporal'
-        assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
-
-    def test_filter_daterange(self):
-        im = self.imagery.filter_daterange(extent=("2016-01-01", "2016-03-10"))
-        graph = im.graph[im.node_id]
-        assert graph['process_id'] == 'filter_temporal'
-        assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
-
-    def test_filter_temporal(self):
-        im = self.imagery.filter_temporal("2016-01-01", "2016-03-10")
-        graph = im.graph[im.node_id]
-        assert graph['process_id'] == 'filter_temporal'
-        assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
-
-    def test_filter_temporal_start_end(self):
-        im = self.imagery.filter_temporal(start_date="2016-01-01", end_date="2016-03-10")
-        graph = im.graph[im.node_id]
-        assert graph['process_id'] == 'filter_temporal'
-        assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
-
-    def test_filter_temporal_extent(self):
-        im = self.imagery.filter_temporal(extent=("2016-01-01", "2016-03-10"))
-        graph = im.graph[im.node_id]
-        assert graph['process_id'] == 'filter_temporal'
-        assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
 
     def test_filter_bbox(self):
         im = self.imagery.filter_bbox(
@@ -156,8 +205,6 @@ class TestRasterCube(TestCase):
                           'type': 'Polygon'})
 
     def test_mask_raster(self):
-        from shapely import geometry
-
         new_imagery = self.imagery.mask(rastermask=self.mask,replacement=102)
 
         graph = new_imagery.graph[new_imagery.node_id]

--- a/tests/test_rastercube.py
+++ b/tests/test_rastercube.py
@@ -26,14 +26,34 @@ class TestRasterCube(TestCase):
         self.mask = ImageCollectionClient(mask_id, builder, connection)
 
     def test_date_range_filter(self):
-        new_imagery = self.imagery.date_range_filter("2016-01-01", "2016-03-10")
+        im = self.imagery.date_range_filter("2016-01-01", "2016-03-10")
+        graph = im.graph[im.node_id]
+        assert graph['process_id'] == 'filter_temporal'
+        assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
 
-        graph = new_imagery.graph[new_imagery.node_id]
+    def test_filter_daterange(self):
+        im = self.imagery.filter_daterange(extent=("2016-01-01", "2016-03-10"))
+        graph = im.graph[im.node_id]
+        assert graph['process_id'] == 'filter_temporal'
+        assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
 
-        self.assertEqual(graph["process_id"], "filter_temporal")
-        self.assertIn("data", graph['arguments'])
-        self.assertEqual(graph["arguments"]["extent"][0], "2016-01-01")
-        self.assertEqual(graph["arguments"]["extent"][1], "2016-03-10")
+    def test_filter_temporal(self):
+        im = self.imagery.filter_temporal("2016-01-01", "2016-03-10")
+        graph = im.graph[im.node_id]
+        assert graph['process_id'] == 'filter_temporal'
+        assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
+
+    def test_filter_temporal_start_end(self):
+        im = self.imagery.filter_temporal(start_date="2016-01-01", end_date="2016-03-10")
+        graph = im.graph[im.node_id]
+        assert graph['process_id'] == 'filter_temporal'
+        assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
+
+    def test_filter_temporal_extent(self):
+        im = self.imagery.filter_temporal(extent=("2016-01-01", "2016-03-10"))
+        graph = im.graph[im.node_id]
+        assert graph['process_id'] == 'filter_temporal'
+        assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
 
     def test_bbox_filter_nsew(self):
         new_imagery = self.imagery.bbox_filter(

--- a/tests/test_rastercube.py
+++ b/tests/test_rastercube.py
@@ -55,47 +55,57 @@ class TestRasterCube(TestCase):
         assert graph['process_id'] == 'filter_temporal'
         assert graph['arguments']['extent'] == ["2016-01-01", "2016-03-10"]
 
-    def test_bbox_filter_nsew(self):
-        new_imagery = self.imagery.bbox_filter(
+    def test_filter_bbox(self):
+        im = self.imagery.filter_bbox(
             west=652000, east=672000, north=5161000, south=5181000, crs="EPSG:32632"
         )
-        graph = new_imagery.graph[new_imagery.node_id]
+        graph = im.graph[im.node_id]
+        assert graph["process_id"] == "filter_bbox"
+        assert graph["arguments"]["extent"] == {
+            "west": 652000, "east": 672000, "north": 5161000, "south": 5181000, "crs": "EPSG:32632"
+        }
 
-        self.assertEqual(graph["process_id"], "filter_bbox")
-        self.assertIn("data", graph['arguments'])
-        self.assertEqual(graph["arguments"]["extent"]["west"], 652000)
-        self.assertEqual(graph["arguments"]["extent"]["east"], 672000)
-        self.assertEqual(graph["arguments"]["extent"]["north"], 5161000)
-        self.assertEqual(graph["arguments"]["extent"]["south"], 5181000)
-        self.assertEqual(graph["arguments"]["extent"]["crs"], "EPSG:32632")
+    def test_filter_bbox_base_height(self):
+        im = self.imagery.filter_bbox(
+            west=652000, east=672000, north=5161000, south=5181000, crs="EPSG:32632",
+            base=100, height=200,
+        )
+        graph = im.graph[im.node_id]
+        assert graph["process_id"] == "filter_bbox"
+        assert graph["arguments"]["extent"] == {
+            "west": 652000, "east": 672000, "north": 5161000, "south": 5181000, "crs": "EPSG:32632",
+            "base": 100, "height": 200,
+        }
+
+    def test_bbox_filter_nsew(self):
+        im = self.imagery.bbox_filter(
+            west=652000, east=672000, north=5161000, south=5181000, crs="EPSG:32632"
+        )
+        graph = im.graph[im.node_id]
+        assert graph["process_id"] == "filter_bbox"
+        assert graph["arguments"]["extent"] == {
+            "west": 652000, "east": 672000, "north": 5161000, "south": 5181000, "crs": "EPSG:32632"
+        }
 
     def test_bbox_filter_tblr(self):
-        new_imagery = self.imagery.bbox_filter(
+        im = self.imagery.bbox_filter(
             left=652000, right=672000, top=5161000, bottom=5181000, srs="EPSG:32632"
         )
-        graph = new_imagery.graph[new_imagery.node_id]
-
-        self.assertEqual(graph["process_id"], "filter_bbox")
-        self.assertIn("data", graph['arguments'])
-        self.assertEqual(graph["arguments"]["extent"]["west"], 652000)
-        self.assertEqual(graph["arguments"]["extent"]["east"], 672000)
-        self.assertEqual(graph["arguments"]["extent"]["north"], 5161000)
-        self.assertEqual(graph["arguments"]["extent"]["south"], 5181000)
-        self.assertEqual(graph["arguments"]["extent"]["crs"], "EPSG:32632")
+        graph = im.graph[im.node_id]
+        assert graph["process_id"] == "filter_bbox"
+        assert graph["arguments"]["extent"] == {
+            "west": 652000, "east": 672000, "north": 5161000, "south": 5181000, "crs": "EPSG:32632"
+        }
 
     def test_bbox_filter_nsew_zero(self):
-        new_imagery = self.imagery.bbox_filter(
+        im = self.imagery.bbox_filter(
             west=0, east=0, north=0, south=0, crs="EPSG:32632"
         )
-        graph = new_imagery.graph[new_imagery.node_id]
-
-        self.assertEqual(graph["process_id"], "filter_bbox")
-        self.assertIn("data", graph['arguments'])
-        self.assertEqual(graph["arguments"]["extent"]["west"], 0)
-        self.assertEqual(graph["arguments"]["extent"]["east"], 0)
-        self.assertEqual(graph["arguments"]["extent"]["north"], 0)
-        self.assertEqual(graph["arguments"]["extent"]["south"], 0)
-        self.assertEqual(graph["arguments"]["extent"]["crs"], "EPSG:32632")
+        graph = im.graph[im.node_id]
+        assert graph["process_id"] == "filter_bbox"
+        assert graph["arguments"]["extent"] == {
+            "west": 0, "east": 0, "north": 0, "south": 0, "crs": "EPSG:32632"
+        }
 
     def test_min_time(self):
         new_imagery = self.imagery.min_time()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 import pytest
 
-from openeo.util import first_not_none
+from openeo.util import first_not_none, get_temporal_extent
 
 
 @pytest.mark.parametrize(['input', 'expected'], [
@@ -24,3 +24,17 @@ def test_first_not_none_failures():
         first_not_none(None)
     with pytest.raises(ValueError):
         first_not_none(None, None)
+
+
+def test_get_temporal_extent():
+    assert get_temporal_extent("2019-03-15") == ("2019-03-15", None)
+    assert get_temporal_extent("2019-03-15", "2019-10-11") == ("2019-03-15", "2019-10-11")
+    assert get_temporal_extent(["2019-03-15", "2019-10-11"]) == ("2019-03-15", "2019-10-11")
+    assert get_temporal_extent(("2019-03-15", "2019-10-11")) == ("2019-03-15", "2019-10-11")
+    assert get_temporal_extent(extent=["2019-03-15", "2019-10-11"]) == ("2019-03-15", "2019-10-11")
+    assert get_temporal_extent(extent=("2019-03-15", "2019-10-11")) == ("2019-03-15", "2019-10-11")
+    assert get_temporal_extent(extent=(None, "2019-10-11")) == (None, "2019-10-11")
+    assert get_temporal_extent(extent=("2019-03-15", None)) == ("2019-03-15", None)
+    assert get_temporal_extent(start_date="2019-03-15", end_date="2019-10-11") == ("2019-03-15", "2019-10-11")
+    assert get_temporal_extent(start_date="2019-03-15") == ("2019-03-15", None)
+    assert get_temporal_extent(end_date="2019-10-11") == (None, "2019-10-11")

--- a/tests/test_zonal_stats.py
+++ b/tests/test_zonal_stats.py
@@ -27,7 +27,7 @@ class TestTimeSeries(TestCase):
         #like the imagecollection ID on: https://earthengine.google.com/datasets/
 
         #access multiband 4D (x/y/time/band) coverage
-        fapar = session.imagecollection("SENTINEL2_FAPAR").bbox_filter(3,6,52,50,"EPSG:4326")
+        fapar = session.imagecollection("SENTINEL2_FAPAR").filter_bbox(3,6,52,50,"EPSG:4326")
 
 
         def check_process_graph(request):


### PR DESCRIPTION
Addresses #67: ImageCollection "API" 
- deprecate old style `date_range_filter`, `filter_daterange` and `bbox_filter`
- promote `filter_temporal` and `filter_bbox` instead (which are more in line with latest spec)
- support different call patterns for `filter_temporal` (no keyword args, with start_date/end_date, with extent)
- provide bit of backwards compatibility with old style subclasess (e.g. for in openeo-geopyspark-driver)