### PR TITLE
Request for comments: Export process graph to Graphviz for visualization

### DIFF
--- a/openeo/rest/imagecollectionclient.py
+++ b/openeo/rest/imagecollectionclient.py
@@ -881,3 +881,16 @@ class ImageCollectionClient(ImageCollection):
         newCollection = ImageCollectionClient(id, newbuilder, self.session)
         newCollection.bands = self.bands
         return newCollection
+
+    def to_graphviz(self):
+        """
+        Build a graphviz DiGraph from the process graph
+        :return:
+        """
+        import graphviz
+        graph = graphviz.Digraph()
+        for name, process in self.graph.items():
+            args = process.get("arguments", {})
+            if "data" in args and "from_node" in args["data"]:
+                graph.edge(args["data"]["from_node"], name)
+        return graph


### PR DESCRIPTION
This is proof of concept to export process graphs to Graphviz objects, which have `_repr_svg_()`, so render nicely in jupyter notebook (https://graphviz.readthedocs.io/en/stable/manual.html#jupyter-notebooks)

The implementation assumes presence of the graphviz python library (https://graphviz.readthedocs.io/en/stable/), which I would define as an optional dependency

usage example:
![Screenshot from 2019-08-29 18-09-06](https://user-images.githubusercontent.com/44946/63957165-30869480-ca88-11e9-8c2c-c5bd5242cb35.png)

