### PR TITLE
Drop requirements.txt in favor of standard dependency declaration in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ python:
 - '3.8'
 install:
 - pip install travis-sphinx==2.1.0 "sphinx<1.7"
-- pip install -r requirements-dev.txt
-- pip install -r requirements.txt
+- pip install .[dev]
 script:
 - pytest
 - travis-sphinx -v build -n --source docs

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Python client API for OpenEO. Allows you to interact with OpenEO backends from y
 
 ## Requirements
 
-* Python 3.5
-* Pip3
+* Python 3.5 or higher
 
 Windows users: It is recommended to install Anaconda Python as shapely may need to be installed separately using the Anaconda Navigator.
 
@@ -22,11 +21,9 @@ Windows users: It is recommended to install Anaconda Python as shapely may need 
 
 ## Development
 
-Installing locally checked out version:
+Install locally checked out version with additional development related dependencies:
 ```bash
-pip install -r requirements.txt
-pip install -r requirements-dev.txt
-pip install -e .
+pip install -e .[dev]
 ```
 Building the documentation:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-sphinx
-sphinx-autodoc-annotation
-mock
-requests-mock
-pytest
-flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-requests
-shapely>=1.6.4
-cloudpickle
-numpy
-pandas
-deprecated

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,16 @@ setup(name=name,
           'pandas',
           'deprecated',
       ],
+      extras_require={
+          "dev": [
+              "sphinx",
+              "sphinx-autodoc-annotation",
+              "mock",
+              "requests-mock",
+              "pytest",
+              "flake8",
+          ]
+      },
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
fixes #74 :

- drop requirement.txt files
- just define deps in setup.py
- simplifies installation procedure