### PR TITLE
Allow specifying OAuth redirect port (and host)

### DIFF
--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -7,7 +7,7 @@ import pathlib
 import shutil
 import sys
 import warnings
-from typing import Dict, List
+from typing import Dict, List, Tuple
 from urllib.parse import urljoin
 
 import requests
@@ -197,7 +197,8 @@ class Connection(RestApiConnection):
         self.auth = BearerAuth(bearer=resp["access_token"])
         return self
 
-    def authenticate_OIDC(self, client_id: str, webbrowser_open=None, timeout=120) -> 'Connection':
+    def authenticate_OIDC(self, client_id: str, webbrowser_open=None, timeout=120,
+                          server_address: Tuple[str, int] = None) -> 'Connection':
         """
         Authenticates a user to the backend using OpenID Connect.
 
@@ -205,6 +206,7 @@ class Connection(RestApiConnection):
         :param webbrowser_open: optional handler for the initial OAuth authentication request
             (opens a webbrowser by default)
         :param timeout: number of seconds after which to abort the authentication procedure
+        :param server_address: optional tuple (hostname, port_number) to serve the OAuth redirect callback on
         """
         # Local import to avoid importing the whole OpenID Connect dependency chain. TODO: just do global import?
         from openeo.rest.auth.oidc import OidcAuthCodePkceAuthenticator
@@ -216,6 +218,7 @@ class Connection(RestApiConnection):
             oidc_discovery_url=oidc_discovery_url,
             webbrowser_open=webbrowser_open,
             timeout=timeout,
+            server_address=server_address,
         )
         # Do the Oauth/OpenID Connect flow and use the access token as bearer token.
         tokens = authenticator.get_tokens()

--- a/tests/rest/auth/test_oidc.py
+++ b/tests/rest/auth/test_oidc.py
@@ -50,6 +50,21 @@ def test_http_server_thread():
     server_thread.join()
 
 
+def test_http_server_thread_port():
+    queue = Queue()
+    server_thread = HttpServerThread(RequestHandlerClass=QueuingRequestHandler.with_queue(queue),
+                                     server_address=('', 12345))
+    server_thread.start()
+    port, host, fqdn = server_thread.server_address_info()
+    assert port == 12345
+    url = 'http://{f}:{p}/foo/bar'.format(f=fqdn, p=port)
+    response = requests.get(url)
+    response.raise_for_status()
+    assert list(drain_queue(queue)) == ['/foo/bar']
+    server_thread.shutdown()
+    server_thread.join()
+
+
 def test_oidc_flow(oidc_test_setup):
     # see test/rest/conftest.py for `oidc_test_setup` fixture
     client_id = "myclient"


### PR DESCRIPTION
based on request of @bgoesswe to allow specifying the port for the OAuth redirect in the OIDC PKCE flow
e.g. like this:
```
con.authenticate_OIDC("openeo-public", timeout=3, server_address=('', 1234))
```