### PR TITLE
EP-3521 remove second callback building method

### DIFF
--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -555,10 +555,7 @@ class DataCube(ImageCollection):
             arguments["target_dimension"] = target_dimension
         result_cube = self.process_with_node(PGNode(process_id="apply_dimension", arguments=arguments))
 
-        if process is None and code is None:
-            return ProcessBuilder(final_callback=ProcessBuilder.datacube_callback(result_cube))
-        else:
-            return result_cube
+        return result_cube
 
     def reduce_dimension(self, dimension: str, reducer: Union[typing.Callable, str],
                          process_id="reduce_dimension", band_math_mode: bool = False) -> 'DataCube':
@@ -667,8 +664,6 @@ class DataCube(ImageCollection):
             process_id='apply_neighborhood',
             arguments=args
         ))
-        if process == None:
-            return ProcessBuilder(final_callback=ProcessBuilder.datacube_callback(result_cube))
         if isinstance(process, typing.Callable):
             builder = ProcessBuilder()
             callback_graph = process(builder)
@@ -698,9 +693,7 @@ class DataCube(ImageCollection):
                 # TODO #125 context
             }
         ))
-        if process == None:
-            return ProcessBuilder(final_callback=ProcessBuilder.datacube_callback(result_cube))
-        elif isinstance(process, typing.Callable):
+        if isinstance(process, typing.Callable):
             builder = ProcessBuilder()
             callback_graph = process(builder)
             result_cube.processgraph_node.arguments['process'] = {'process_graph': callback_graph.pgnode}

--- a/openeo/rest/processbuilder.py
+++ b/openeo/rest/processbuilder.py
@@ -43,22 +43,12 @@ class ProcessBuilder(ImageCollection):
 
     PARENT='PARENT'
 
-    @classmethod
-    def datacube_callback(cls,datacube:'DataCube'):
-        def callback(pgnode,process_argname='process'):
-            parent_node = datacube.processgraph_node
-            parent_node.arguments[process_argname] = {'process_graph':pgnode}
-            return datacube
-        return callback
-
-    def __init__(self, final_callback=None, pgnode=None, parent_data_parameter='data'):
+    def __init__(self, pgnode=None, parent_data_parameter='data'):
         """
 
-        @param final_callback: A function to invoke when the graph is ready.
         @param pgnode:
         @param parent_data_parameter:
         """
-        self.final_callback = final_callback
         self.pgnode = pgnode
         self.parent_data_parameter = parent_data_parameter
 
@@ -97,10 +87,5 @@ class ProcessBuilder(ImageCollection):
         :return: new DataCube instance
         """
         arguments = {**(arguments or {}), **kwargs}
-        return ProcessBuilder(self.final_callback, PGNode(process_id=process_id, arguments=arguments))
+        return ProcessBuilder(PGNode(process_id=process_id, arguments=arguments))
 
-    def done(self):
-        return self.finish()
-
-    def finish(self):
-        return self.final_callback(self.pgnode)

--- a/tests/rest/datacube/test_datacube100.py
+++ b/tests/rest/datacube/test_datacube100.py
@@ -253,10 +253,10 @@ def test_apply_absolute_pgnode(con100):
     expected_graph = load_json_resource('data/1.0.0/apply_absolute.json')
     assert result.graph == expected_graph
 
+
 def test_apply_absolute_callback(con100):
     im = con100.load_collection("S2")
-    result = im.apply().absolute().done()
-
+    result = im.apply(lambda data: data.absolute())
     expected_graph = load_json_resource('data/1.0.0/apply_absolute.json')
     assert result.graph == expected_graph
 

--- a/tests/rest/datacube/test_processbuilder.py
+++ b/tests/rest/datacube/test_processbuilder.py
@@ -1,18 +1,6 @@
 from openeo.rest.processbuilder import ProcessBuilder
 
 
-def test_apply_neighborhood_udf(con100):
-    collection = con100.load_collection("S2")
-    callback = collection.apply_neighborhood( size=[
-        {'dimension': 'x', 'value': 128, 'unit': 'px'},
-        {'dimension': 'y', 'value': 128, 'unit': 'px'}
-    ], overlap=[
-        {'dimension': 't', 'value': 'P10d'},
-    ])
-    neighbors = callback.run_udf(code='myfancycode',runtime='Python').done()
-    check_apply_neighbors(neighbors)
-
-
 def check_apply_neighbors(neighbors):
     actual_graph = neighbors.graph['applyneighborhood1']
     assert actual_graph == {'arguments': {'data': {'from_node': 'loadcollection1'},


### PR DESCRIPTION
follow-up of #149: we decided to pick method 1, method 2 is probably too confusing for Python users
removing method 2 again cleans up things quite a bit