### PR TITLE
EP-3521 fix parameter name "x" in "apply" callback

### DIFF
--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -683,7 +683,7 @@ class DataCube(ImageCollection):
             # Simple single string process specification
             process = PGNode(
                 process_id=process,
-                arguments={data_argument: {"from_parameter": "data"}}
+                arguments={data_argument: {"from_parameter": "x"}}
             )
         result_cube = self.process_with_node(PGNode(
             process_id='apply',
@@ -694,7 +694,7 @@ class DataCube(ImageCollection):
             }
         ))
         if isinstance(process, typing.Callable):
-            builder = ProcessBuilder()
+            builder = ProcessBuilder(parent_data_parameter="x")
             callback_graph = process(builder)
             result_cube.processgraph_node.arguments['process'] = {'process_graph': callback_graph.pgnode}
 

--- a/openeo/rest/processbuilder.py
+++ b/openeo/rest/processbuilder.py
@@ -89,3 +89,7 @@ class ProcessBuilder(ImageCollection):
         arguments = {**(arguments or {}), **kwargs}
         return ProcessBuilder(PGNode(process_id=process_id, arguments=arguments))
 
+
+
+def absolute(data: ProcessBuilder) -> ProcessBuilder:
+    return data.absolute()

--- a/tests/data/1.0.0/apply_absolute.json
+++ b/tests/data/1.0.0/apply_absolute.json
@@ -19,7 +19,7 @@
             "process_id": "absolute",
             "arguments": {
               "x": {
-                "from_parameter": "data"
+                "from_parameter": "x"
               }
             },
             "result": true

--- a/tests/rest/datacube/test_datacube100.py
+++ b/tests/rest/datacube/test_datacube100.py
@@ -249,14 +249,22 @@ def test_metadata_load_collection_100(con100, requests_mock):
 
 def test_apply_absolute_pgnode(con100):
     im = con100.load_collection("S2")
-    result = im.apply(PGNode(process_id="absolute", arguments={"x": {"from_parameter": "data"}}))
+    result = im.apply(PGNode(process_id="absolute", arguments={"x": {"from_parameter": "x"}}))
     expected_graph = load_json_resource('data/1.0.0/apply_absolute.json')
     assert result.graph == expected_graph
 
 
-def test_apply_absolute_callback(con100):
+def test_apply_absolute_callback_lambda_method(con100):
     im = con100.load_collection("S2")
     result = im.apply(lambda data: data.absolute())
+    expected_graph = load_json_resource('data/1.0.0/apply_absolute.json')
+    assert result.graph == expected_graph
+
+
+def test_apply_absolute_callback_function(con100):
+    im = con100.load_collection("S2")
+    from openeo.rest.processbuilder import absolute
+    result = im.apply(absolute)
     expected_graph = load_json_resource('data/1.0.0/apply_absolute.json')
     assert result.graph == expected_graph
 

--- a/tests/rest/datacube/test_processbuilder.py
+++ b/tests/rest/datacube/test_processbuilder.py
@@ -59,29 +59,39 @@ def test_apply_neighborhood_complex_callback(con100):
                             'result': True}
 
 
-def test_apply_bandmath(con100):
-    collection = con100.load_collection("S2")
-
+def test_apply_dimension_bandmath(con100):
     from openeo.rest.processbuilder import array_element
 
-    bandsum = collection.apply(process=lambda data:array_element(data,index=1) + array_element(data,index=2))
+    collection = con100.load_collection("S2")
+    bandsum = collection.apply_dimension(
+        process=lambda d: array_element(d, index=1) + array_element(d, index=2),
+        dimension="bands"
+    )
 
-    actual_graph = bandsum.graph['apply1']
-    assert actual_graph == {'arguments': {'data': {'from_node': 'loadcollection1'},
-
-                                          'process': {'process_graph': {'add1': {'arguments': {'x': {'from_node': 'arrayelement1'},
-                                                                    'y': {'from_node': 'arrayelement2'}},
-                                                      'process_id': 'add',
-                                                      'result': True},
-                                             'arrayelement1': {'arguments': {'data': {'from_parameter': 'data'},
-                                                                             'index': 1},
-                                                               'process_id': 'array_element'},
-                                             'arrayelement2': {'arguments': {'data': {'from_parameter': 'data'},
-                                                                             'index': 2},
-                                                               'process_id': 'array_element'}}}},
-                            'process_id': 'apply',
-                            'result': True}
-
+    actual_graph = bandsum.graph['applydimension1']
+    assert actual_graph == {
+        'process_id': 'apply_dimension',
+        'arguments': {
+            'data': {'from_node': 'loadcollection1'},
+            'dimension': 'bands',
+            'process': {'process_graph': {
+                'arrayelement1': {
+                    'process_id': 'array_element',
+                    'arguments': {'data': {'from_parameter': 'data'}, 'index': 1},
+                },
+                'arrayelement2': {
+                    'process_id': 'array_element',
+                    'arguments': {'data': {'from_parameter': 'data'}, 'index': 2},
+                },
+                'add1': {
+                    'process_id': 'add',
+                    'arguments': {'x': {'from_node': 'arrayelement1'}, 'y': {'from_node': 'arrayelement2'}},
+                    'result': True
+                },
+            }}
+        },
+        'result': True
+    }
 
 
 def test_reduce_dimension(con100):


### PR DESCRIPTION
follow-up of #149: @jdries   you changed a `from_parameter` in an `apply` callback from `x` to `data`:
https://github.com/Open-EO/openeo-python-client/blob/9e56beab772c3e91e51b905659cea17a6265a946/tests/data/1.0.0/apply_absolute.json#L10-L22

but from my understanding of the definition of the `apply` process (https://openeo.org/documentation/1.0/processes.html#apply),  the callback does get its input through parameter `x` (while the parent process indeed has the whole cube under `data`). So I think it should be like this:

      "apply1": {
        "process_id": "apply",
        "arguments": {
          "data": { "from_node": "loadcollection1"},
          "process": {
            "process_graph": {
              "absolute1": {
                "process_id": "absolute",
                "arguments": {
                  "x": { "from_parameter": "x"

@m-mohr   can you confirm which one is correct?