### PR TITLE
correct hand over of job options in send_job

### DIFF
--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -783,9 +783,6 @@ class Connection(RestApiConnection):
             process_graph=process_graph,
             title=title, description=description, plan=plan, budget=budget
         )
-        if additional:
-            # TODO: get rid of this non-standard field? https://github.com/Open-EO/openeo-api/issues/276
-            req["job_options"] = additional
 
         response = self.post("/jobs", json=req, expected_status=201)
 

--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -1172,8 +1172,7 @@ class DataCube(ImageCollection):
                 result._download_url(iurl["href"], pathlib.Path(iname))
                 
         return job;
-        
-        
+
     def send_job(self, out_format=None, job_options=None, **format_options) -> RESTJob:
         """
         Sends a job to the backend and returns a Job instance. The job will still need to be started and managed explicitly.
@@ -1188,7 +1187,8 @@ class DataCube(ImageCollection):
         if out_format:
             # add `save_result` node
             img = img.save_result(format=out_format, options=format_options)
-        return self._connection.create_job(process_graph=img.graph, additional=job_options)
+        job_options = dict() if job_options is None else job_options
+        return self._connection.create_job(process_graph=img.graph, **job_options)
 
     def save_user_defined_process(self, user_defined_process_id: str, public: bool = False) -> RESTUserDefinedProcess:
         """


### PR DESCRIPTION
In `send_job`, job options like `title`, `budget`, `description`, ... where not used and send as `None` values to the back-end. This PR should fix this.