### PR TITLE
Issue #192: add support for default OIDC clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add dependency on `xarray` package ([#159](https://github.com/Open-EO/openeo-python-client/issues/159), [#190](https://github.com/Open-EO/openeo-python-client/pull/190), EP-3578)
+- Add support for default OIDC clients advertised by backend ([#192](https://github.com/Open-EO/openeo-python-client/issues/192), [Open-EO/openeo-api#366](https://github.com/Open-EO/openeo-api/pull/366))
+
 
 ### Changed
 

--- a/openeo/rest/auth/cli.py
+++ b/openeo/rest/auth/cli.py
@@ -252,18 +252,18 @@ def main_add_oidc(args):
 
     # Get client_id and client_secret (if necessary)
     if use_default_client:
-        if not provider.default_client:
-            show_warning("No default client specified for provider {p!r}".format(p=provider_id))
+        if not provider.default_clients:
+            show_warning("No default clients declared for provider {p!r}".format(p=provider_id))
         client_id, client_secret = None, None
     else:
         if not client_id:
-            if provider.default_client:
+            if provider.default_clients:
                 client_prompt = "Enter client_id or leave empty to use default client, and press enter: "
             else:
                 client_prompt = "Enter client_id and press enter: "
             client_id = builtins.input(client_prompt).strip() or None
         print("Using client ID {u!r}".format(u=client_id))
-        if not client_id and not provider.default_client:
+        if not client_id and not provider.default_clients:
             show_warning("Given client ID was empty.")
 
         if client_id and ask_client_secret:

--- a/tests/rest/test_connection.py
+++ b/tests/rest/test_connection.py
@@ -961,7 +961,10 @@ def test_authenticate_oidc_device_flow_multiple_provider_one_config_no_given_def
             {"id": "fauth", "issuer": "https://fauth.test", "title": "Foo", "scopes": ["openid"]},
             {
                 "id": "bauth", "issuer": "https://bauth.test", "title": "Bar", "scopes": ["openid"],
-                "default_client": {"id": default_client_id}
+                "default_clients": [{
+                    "id": default_client_id,
+                    "grant_types": ["urn:ietf:params:oauth:grant-type:device_code+pkce", "refresh_token"]
+                }]
             },
         ]
     })


### PR DESCRIPTION
update Issue #192: Initial experimental implementation with a single default_client had to be adapted to multiple default clients from updated draft spec (Open-EO/openeo-api#366 was merged).

Not fully tested yet, I'm waiting for changes to VITO backend to be deployed