### PR TITLE
Remove non-standard `srs` argument from `mask_polygon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove non-standard `srs` argument from `DataCube.mask_polygon` hmethod (EP-3747 related)
+
 ### Fixed
 
 - `Connection`: don't send default auth headers to non-backend domains ([#201](https://github.com/Open-EO/openeo-python-client/issues/201))

--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -1112,7 +1112,7 @@ class DataCube(ImageCollection):
 
     def mask_polygon(
             self, mask: Union[Polygon, MultiPolygon, str, pathlib.Path] = None,
-            srs="EPSG:4326", replacement=None, inside: bool = None
+            replacement=None, inside: bool = None
     ) -> 'DataCube':
         """
         Applies a polygon mask to a raster data cube. To apply a raster mask use `mask`.
@@ -1124,9 +1124,11 @@ class DataCube(ImageCollection):
         The pixel values are replaced with the value specified for `replacement`,
         which defaults to `no data`.
 
-        :param mask: A polygon, provided as a :class:`shapely.geometry.Polygon` or :class:`shapely.geometry.MultiPolygon`, or a filename pointing to a valid vector file
-        :param srs: The reference system of the provided polygon, by default this is Lat Lon (EPSG:4326).
+        :param mask: A polygon, provided as a :class:`shapely.geometry.Polygon`
+            or :class:`shapely.geometry.MultiPolygon`, or a filename pointing to a valid vector file
         :param replacement: the value to replace the masked pixels with
+        :param inside: If set to true all pixels for which the point at the pixel center
+            does intersect with any polygon are replaced.
         """
         if isinstance(mask, (str, pathlib.Path)):
             # TODO: default to loading file client side?
@@ -1140,10 +1142,6 @@ class DataCube(ImageCollection):
             if mask.area == 0:
                 raise ValueError("Mask {m!s} has an area of {a!r}".format(m=mask, a=mask.area))
             mask = shapely.geometry.mapping(mask)
-            mask['crs'] = {
-                'type': 'name',
-                'properties': {'name': srs}
-            }
         elif isinstance(mask, Parameter):
             pass
         else:

--- a/openeo/rest/imagecollectionclient.py
+++ b/openeo/rest/imagecollectionclient.py
@@ -763,7 +763,7 @@ class ImageCollectionClient(ImageCollection):
         }
         return self.graph_add_process(process_id, args)
 
-    def mask(self, polygon: Union[Polygon, MultiPolygon,str]=None, srs="EPSG:4326", rastermask: 'ImageCollection'=None,
+    def mask(self, polygon: Union[Polygon, MultiPolygon,str]=None, rastermask: 'ImageCollection'=None,
              replacement=None) -> 'ImageCollection':
         """
         Mask the image collection using either a polygon or a raster mask.
@@ -781,7 +781,6 @@ class ImageCollectionClient(ImageCollection):
         # TODO: also see `mask` vs `mask_polygon` processes in https://github.com/Open-EO/openeo-processes/pull/110
 
         :param polygon: A polygon, provided as a :class:`shapely.geometry.Polygon` or :class:`shapely.geometry.MultiPolygon`, or a filename pointing to a valid vector file
-        :param srs: The reference system of the provided polygon, by default this is Lat Lon (EPSG:4326).
         :param rastermask: the raster mask
         :param replacement: the value to replace the masked pixels with
         :raise: :class:`ValueError` if a polygon is supplied and its area is 0.
@@ -805,12 +804,6 @@ class ImageCollectionClient(ImageCollection):
                     raise ValueError("Mask {m!s} has an area of {a!r}".format(m=polygon, a=polygon.area))
 
                 geojson = mapping(polygon)
-                geojson['crs'] = {
-                    'type': 'name',
-                    'properties': {
-                        'name': srs
-                    }
-                }
                 mask = geojson
                 new_collection = self
         elif rastermask is not None:

--- a/tests/rest/datacube/test_datacube.py
+++ b/tests/rest/datacube/test_datacube.py
@@ -320,9 +320,8 @@ def test_mask_polygon(s2cube, api_version):
     assert graph["arguments"] == {
         "data": {'from_node': 'loadcollection1'},
         "mask": {
+            'type': 'Polygon',
             'coordinates': (((0.0, 0.0), (1.9, 0.0), (1.9, 1.9), (0.0, 1.9), (0.0, 0.0)),),
-            'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},
-            'type': 'Polygon'
         }
     }
 

--- a/tests/rest/datacube/test_datacube100.py
+++ b/tests/rest/datacube/test_datacube100.py
@@ -166,9 +166,9 @@ def test_mask_polygon(con100: Connection):
         "arguments": {
             "data": {"from_node": "loadcollection1"},
             'mask': {
+                'type': 'Polygon',
                 'coordinates': (((1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0), (1.0, 0.0)),),
-                'crs': {'properties': {'name': 'EPSG:4326'}, 'type': 'name'},
-                'type': 'Polygon'}
+            }
         },
         "result": True
     }


### PR DESCRIPTION
geojson as used in `mask_polygon` is EPSG:4326/WGS84 only and openEO API currently does not provide way to extend this.


Current implementation in DataCube (and ImageCollectionClient) provides an additional `srs` argument to specify an alternative reference system, which is non-standard, not supported by a backend as far as I know .
Also the coverage of `srs` is incomplete: only the code path that handles a shapely geometry uses `srs`.
Other code paths do not. While it could be possible to add it to the `read_vector` and `dict` code paths, it is not possible for the `Parameter` code path without extending the API

I would just remove the `srs` argument.

(related EP-3747, Open-EO/openeo-processes#53)