### PR TITLE
More Jupyter visualizations + Services

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,6 +30,9 @@ openeo.api
 .. automodule:: openeo.api.process
     :members: Parameter
 
+.. automodule:: openeo.api.logs
+    :members: LogEntry
+
 
 openeo.rest.connection
 ----------------------
@@ -42,7 +45,7 @@ openeo.rest.job
 ----------------------
 
 .. automodule:: openeo.rest.job
-    :members: RESTJob, JobLogEntry, JobResults, ResultAsset
+    :members: RESTJob, JobResults, ResultAsset
 
 
 openeo.rest.conversions

--- a/openeo/api/logs.py
+++ b/openeo/api/logs.py
@@ -6,7 +6,7 @@ class LogEntry:
     """
 
     def __init__(self, entry):
-        self.log_id = entry['id']
+        self.id = entry['id']
         self.code = entry.get("code", 0)
         self.level = entry['level']
         self.message = entry['message']
@@ -15,6 +15,3 @@ class LogEntry:
         self.links = entry.get("links", [])
         if 'data' in entry:
             self.data = entry['data']
-
-    def toJson(self):
-        return json.dumps(self, default = lambda o: o.__dict__) # doesn't work

--- a/openeo/api/logs.py
+++ b/openeo/api/logs.py
@@ -1,0 +1,20 @@
+import json
+
+class LogEntry:
+    """
+    A log entry.
+    """
+
+    def __init__(self, entry):
+        self.log_id = entry['id']
+        self.code = entry.get("code", 0)
+        self.level = entry['level']
+        self.message = entry['message']
+        self.time =  entry.get("time", None) # todo: native date/time object?
+        self.path = entry.get("path", [])
+        self.links = entry.get("links", [])
+        if 'data' in entry:
+            self.data = entry['data']
+
+    def toJson(self):
+        return json.dumps(self, default = lambda o: o.__dict__) # doesn't work

--- a/openeo/api/logs.py
+++ b/openeo/api/logs.py
@@ -6,12 +6,37 @@ class LogEntry:
     """
 
     def __init__(self, entry):
+        # Unique ID for the log, string, REQUIRED
         self.id = entry['id']
-        self.code = entry.get("code", 0)
+
+        # Error code, string, optional
+        self.code = entry.get("code", "")
+
+        # Severity level, string (error, warning, info or debug), REQUIRED
         self.level = entry['level']
+
+        # Error message, string, REQUIRED
         self.message = entry['message']
-        self.time =  entry.get("time", None) # todo: native date/time object?
+
+        # Date and time of the error event as RFC3339 date-time, string, available since API 1.1.0
+        # todo: Use native date/time object?
+        self.time =  entry.get("time", None)
+
+        # A "stack trace" for the process, array of dicts
         self.path = entry.get("path", [])
+
+        # Related links, array of dicts
         self.links = entry.get("links", [])
+
+        # Usage metrics, dict, available since API 1.1.0
+        # May contain the following metrics: cpu, memory, duration, network, disk, storage and other custom ones
+        # Each of the metrics is also a dict with the following parts: value (numeric) and unit (string)
+        self.usage = entry.get("usage", {})
+        
+        # Arbritrary data the user wants to "log" for debugging purposes.
+        # Please note that this property may not exist as there's a difference
+        # between None and non-existing. None for example refers to no-data in
+        # many cases while the absence of the property means that the user did 
+        # not provide any data for debugging.
         if 'data' in entry:
             self.data = entry['data']

--- a/openeo/imagecollection.py
+++ b/openeo/imagecollection.py
@@ -7,7 +7,7 @@ from deprecated import deprecated
 from shapely.geometry import Polygon, MultiPolygon
 
 from openeo.rest.job import RESTJob
-from openeo.service import Service
+from openeo.rest.service import Service
 from openeo.util import get_temporal_extent, first_not_none
 
 

--- a/openeo/imagecollection.py
+++ b/openeo/imagecollection.py
@@ -7,6 +7,7 @@ from deprecated import deprecated
 from shapely.geometry import Polygon, MultiPolygon
 
 from openeo.rest.job import RESTJob
+from openeo.service import Service
 from openeo.util import get_temporal_extent, first_not_none
 
 
@@ -483,14 +484,14 @@ class ImageCollection(ABC):
         """
         pass
 
-    def tiled_viewing_service(self, **kwargs) -> Dict:
+    def tiled_viewing_service(self, **kwargs) -> Service:
         """
         Returns metadata for a tiled viewing service that visualizes this layer.
 
         :param process_graph: process graph dict
         :param service_type: The type of viewing service to create, for instance: 'WMTS'
 
-        :return: A dictionary object containing the viewing service metadata, such as the connection 'url'.
+        :return: A service object.
         """
         pass
 

--- a/openeo/internal/jupyter.py
+++ b/openeo/internal/jupyter.py
@@ -8,6 +8,7 @@ COMPONENT_MAP = {
     'file-format': 'format',
     'file-formats': 'formats',
     'item': 'data',
+    'job-estimate': 'estimate',
     'service-type': 'service',
     'service-types': 'services',
     'udf-runtime': 'runtime',

--- a/openeo/internal/jupyter.py
+++ b/openeo/internal/jupyter.py
@@ -105,7 +105,7 @@ def render_component(component: str, data = None, parameters: dict = {}):
     """.format(
         script = SCRIPT_URL,
         component = component,
-        props = json.dumps(parameters)
+        props = json.dumps(parameters, default = lambda o: o.__dict__) # default parameter added to serialize LogEntry
     )
 
 def render_error(error: OpenEoApiError):

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -229,6 +229,9 @@ class Connection(RestApiConnection):
         self._auth_config = auth_config
         self._refresh_token_store = refresh_token_store
 
+    def _repr_html_(self):
+        return self.capabilities()._repr_html_()
+
     @classmethod
     def version_discovery(cls, url: str, session: requests.Session = None) -> str:
         """

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -937,7 +937,7 @@ class Connection(RestApiConnection):
         :param job_id: the service id of an existing secondary web service
         :return: A service object.
         """
-        return Service(service_id, self)
+        return Service(service_id, connection=self)
 
     def load_disk_collection(self, format: str, glob_pattern: str, options: dict = {}) -> ImageCollectionClient:
         """
@@ -1016,4 +1016,3 @@ def paginate(con: Connection, url: str, params: dict = None, callback: Callable 
         url = next_links[0]["href"]
         page += 1
         params = {}
-

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -31,8 +31,8 @@ from openeo.rest.datacube import DataCube
 from openeo.rest.imagecollectionclient import ImageCollectionClient
 from openeo.rest.job import RESTJob
 from openeo.rest.rest_capabilities import RESTCapabilities
+from openeo.rest.service import Service
 from openeo.rest.udp import RESTUserDefinedProcess, Parameter
-from openeo.service import Service
 from openeo.util import ensure_list, legacy_alias, dict_no_none, rfc3339
 
 _log = logging.getLogger(__name__)
@@ -799,7 +799,7 @@ class Connection(RestApiConnection):
         service_id = response.headers.get("OpenEO-Identifier")
         return Service(service_id, self)
 
-    @deprecated("Use :py:meth:`openeo.service.Service.delete_service` instead.", version="0.7.0")
+    @deprecated("Use :py:meth:`openeo.rest.service.Service.delete_service` instead.", version="0.7.1")
     def remove_service(self, service_id: str):
         """
         Stop and remove a secondary web service.

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -32,6 +32,7 @@ from openeo.rest.imagecollectionclient import ImageCollectionClient
 from openeo.rest.job import RESTJob
 from openeo.rest.rest_capabilities import RESTCapabilities
 from openeo.rest.udp import RESTUserDefinedProcess, Parameter
+from openeo.service import Service
 from openeo.util import ensure_list, legacy_alias, dict_no_none, rfc3339
 
 _log = logging.getLogger(__name__)
@@ -791,17 +792,14 @@ class Connection(RestApiConnection):
 
     imagecollection = legacy_alias(load_collection, name="imagecollection")
 
-    def create_service(self, graph: dict, type: str, **kwargs) -> dict:
+    def create_service(self, graph: dict, type: str, **kwargs) -> Service:
         # TODO: type hint for graph: is it a nested or a flat one?
         req = self._build_request_with_process_graph(process_graph=graph, type=type, **kwargs)
         response = self.post(path="/services", json=req, expected_status=201)
-        # TODO: "location" is url of the service metadata, not (base) url of service (https://github.com/Open-EO/openeo-api/issues/269)
-        # TODO: fetch this metadata and return a full metadata object instead?
-        return {
-            'url': response.headers.get('Location'),
-            'service_id': response.headers.get("OpenEO-Identifier"),
-        }
+        service_id = response.headers.get("OpenEO-Identifier")
+        return Service(service_id, self)
 
+    @deprecated("Use :py:meth:`openeo.service.Service.delete_service` instead.", version="0.7.0")
     def remove_service(self, service_id: str):
         """
         Stop and remove a secondary web service.
@@ -809,7 +807,7 @@ class Connection(RestApiConnection):
         :param service_id: service identifier
         :return:
         """
-        response = self.delete('/services/' + service_id)
+        Service(service_id, self).delete_service()
 
     @deprecated("Use :py:meth:`openeo.rest.job.RESTJob.get_results` instead.", version="0.4.10")
     def job_results(self, job_id) -> dict:
@@ -926,6 +924,17 @@ class Connection(RestApiConnection):
         :return: A job object.
         """
         return RESTJob(job_id, self)
+
+    def service(self, service_id: str) -> Service:
+        """
+        Get the secondary web service based on the id. The service with the given id should already exist.
+        
+        Use :py:meth:`openeo.rest.connection.Connection.create_service` to create new services
+
+        :param job_id: the service id of an existing secondary web service
+        :return: A service object.
+        """
+        return Service(service_id, self)
 
     def load_disk_collection(self, format: str, glob_pattern: str, options: dict = {}) -> ImageCollectionClient:
         """

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -722,7 +722,8 @@ class Connection(RestApiConnection):
         """
         Lists all user-defined processes of the authenticated user.
         """
-        return self.get("/process_graphs").json()["processes"]
+        data = self.get("/process_graphs").json()["processes"]
+        return VisualList("processes", data = data)
 
     def user_defined_process(self, user_defined_process_id: str) -> RESTUserDefinedProcess:
         """

--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -25,7 +25,6 @@ from shapely.geometry import Polygon, MultiPolygon, mapping
 
 import openeo
 import openeo.processes
-from openeo.service import Service
 from openeo.api.process import Parameter
 from openeo.imagecollection import ImageCollection
 from openeo.internal.graph_building import PGNode, ReduceNode
@@ -33,6 +32,7 @@ from openeo.metadata import CollectionMetadata, Band, BandDimension
 from openeo.processes import ProcessBuilder
 from openeo.rest import BandMathException, OperatorException, OpenEoClientException
 from openeo.rest.job import RESTJob
+from openeo.rest.service import Service
 from openeo.rest.udp import RESTUserDefinedProcess
 from openeo.rest.vectorcube import VectorCube
 from openeo.util import get_temporal_extent, dict_no_none, legacy_alias, rfc3339

--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -25,6 +25,7 @@ from shapely.geometry import Polygon, MultiPolygon, mapping
 
 import openeo
 import openeo.processes
+from openeo.service import Service
 from openeo.api.process import Parameter
 from openeo.imagecollection import ImageCollection
 from openeo.internal.graph_building import PGNode, ReduceNode
@@ -1392,7 +1393,7 @@ class DataCube(ImageCollection):
         cube = self.save_result(format=format, options=options)
         return self._connection.download(cube.flat_graph(), outputfile)
 
-    def tiled_viewing_service(self, type: str, **kwargs) -> Dict:
+    def tiled_viewing_service(self, type: str, **kwargs) -> Service:
         return self._connection.create_service(self.flat_graph(), type=type, **kwargs)
 
     def execute_batch(

--- a/openeo/rest/imagecollectionclient.py
+++ b/openeo/rest/imagecollectionclient.py
@@ -7,12 +7,12 @@ from typing import List, Dict, Union, Tuple
 
 from shapely.geometry import Polygon, MultiPolygon, mapping
 
-from openeo.service import Service
 from openeo.imagecollection import ImageCollection
 from openeo.internal.graphbuilder_040 import GraphBuilder
 from openeo.metadata import CollectionMetadata
 from openeo.rest import BandMathException
 from openeo.rest.job import RESTJob
+from openeo.rest.service import Service
 from openeo.util import get_temporal_extent, legacy_alias
 
 if hasattr(typing, 'TYPE_CHECKING') and typing.TYPE_CHECKING:

--- a/openeo/rest/imagecollectionclient.py
+++ b/openeo/rest/imagecollectionclient.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Union, Tuple
 
 from shapely.geometry import Polygon, MultiPolygon, mapping
 
+from openeo.service import Service
 from openeo.imagecollection import ImageCollection
 from openeo.internal.graphbuilder_040 import GraphBuilder
 from openeo.metadata import CollectionMetadata
@@ -980,7 +981,7 @@ class ImageCollectionClient(ImageCollection):
         newcollection.graph[newcollection.node_id]["result"] = True
         return self.session.download(newcollection.graph, outputfile)
 
-    def tiled_viewing_service(self, type: str, **kwargs) -> Dict:
+    def tiled_viewing_service(self, type: str, **kwargs) -> Service:
         self.graph[self.node_id]['result'] = True
         return self.session.create_service(self.graph, type=type, **kwargs)
 

--- a/openeo/rest/job.py
+++ b/openeo/rest/job.py
@@ -28,12 +28,12 @@ class JobLogEntry:
 
     def __init__(self, entry):
         self.log_id = entry['id']
-        self.code = entry['code'] if 'code' in entry else 0
+        self.code = entry.get("code", 0)
         self.level = entry['level']
         self.message = entry['message']
-        self.time =  entry['time'] if 'time' in entry else None # todo: native date/time object?
-        self.path = entry['path'] if 'path' in entry else []
-        self.links = entry['links'] if 'links' in entry else []
+        self.time =  entry.get("time", None) # todo: native date/time object?
+        self.path = entry.get("path", [])
+        self.links = entry.get("links", [])
         if 'data' in entry:
             self.data = entry['data']
 

--- a/openeo/rest/job.py
+++ b/openeo/rest/job.py
@@ -37,14 +37,14 @@ class RESTJob:
         return '<{c} job_id={i!r}>'.format(c=self.__class__.__name__, i=self.job_id)
 
     def _repr_html_(self):
-        return self.describe_job()._repr_html_()
+        data = self.describe_job()
+        currency = self.connection.capabilities().currency()
+        return render_component('job', data = data, parameters = {'currency': currency})
 
     def describe_job(self):
         """ Get all job information."""
         # GET /jobs/{job_id}
-        data = self.connection.get("/jobs/{}".format(self.job_id), expected_status=200).json()
-        currency = self.connection.capabilities().currency()
-        return VisualDict('job', data = data, parameters = {'currency': currency})
+        return self.connection.get("/jobs/{}".format(self.job_id), expected_status=200).json()
 
     def update_job(self, process_graph=None, output_format=None,
                    output_parameters=None, title=None, description=None,

--- a/openeo/rest/service.py
+++ b/openeo/rest/service.py
@@ -15,14 +15,14 @@ class Service:
         return '<{c} service_id={i!r}>'.format(c=self.__class__.__name__, i=self.service_id)
 
     def _repr_html_(self):
-        return self.describe_service()._repr_html_()
+        data = self.describe_service()
+        currency = self.connection.capabilities().currency()
+        return VisualDict('service', data = data, parameters = {'currency': currency})
 
     def describe_service(self):
         """ Get all information about a secondary web service."""
         # GET /services/{service_id}
-        data = self.connection.get("/services/{}".format(self.service_id), expected_status=200).json()
-        currency = self.connection.capabilities().currency()
-        return VisualDict('service', data = data, parameters = {'currency': currency})
+        return self.connection.get("/services/{}".format(self.service_id), expected_status=200).json()
 
     def update_service(self, process_graph=None, title=None, description=None, enabled=None, configuration=None, plan=None, budget=None, additional=None):
         """ Update a secondary web service."""

--- a/openeo/rest/service.py
+++ b/openeo/rest/service.py
@@ -1,9 +1,8 @@
-from abc import ABC
 from typing import List
 from openeo.internal.jupyter import VisualDict, VisualList
 from openeo.api.logs import LogEntry
 
-class Service(ABC):
+class Service:
     """Represents a secondary web service in openeo."""
 
     def __init__(self, service_id: str, connection: 'Connection'):
@@ -25,8 +24,7 @@ class Service(ABC):
         currency = self.connection.capabilities().currency()
         return VisualDict('service', data = data, parameters = {'currency': currency})
 
-    def update_service(self, process_graph=None, title=None, description=None,
-                       enabled=None, parameters=None, plan=None, budget=None):
+    def update_service(self, process_graph=None, title=None, description=None, enabled=None, configuration=None, plan=None, budget=None, additional=None):
         """ Update a secondary web service."""
         # PATCH /services/{service_id}
         raise NotImplementedError

--- a/openeo/rest/service.py
+++ b/openeo/rest/service.py
@@ -6,9 +6,8 @@ class Service:
     """Represents a secondary web service in openeo."""
 
     def __init__(self, service_id: str, connection: 'Connection'):
+        # Unique identifier of the secondary web service (string)
         self.service_id = service_id
-        """Unique identifier of the secondary web service (string)."""
-
         self.connection = connection
 
     def __repr__(self):

--- a/openeo/rest/udp.py
+++ b/openeo/rest/udp.py
@@ -7,6 +7,7 @@ from openeo.api.process import Parameter
 from openeo.internal.graph_building import as_flat_graph
 from openeo.internal.processes.builder import ProcessBuilderBase
 from openeo.util import dict_no_none
+from openeo.internal.jupyter import VisualDict
 
 if hasattr(typing, 'TYPE_CHECKING') and typing.TYPE_CHECKING:
     # Only import this for type hinting purposes. Runtime import causes circular dependency issues.
@@ -53,6 +54,9 @@ class RESTUserDefinedProcess:
         self.user_defined_process_id = user_defined_process_id
         self._connection = connection
 
+    def _repr_html_(self):
+        return self.describe()._repr_html_()
+
     def store(
             self, process_graph: Union[dict, ProcessBuilderBase], parameters: List[Union[Parameter, dict]] = None,
             public: bool = False, summary: str = None, description: str = None
@@ -80,7 +84,8 @@ class RESTUserDefinedProcess:
 
     def describe(self) -> dict:
         # TODO: parse the "parameters" to Parameter objects?
-        return self._connection.get(path="/process_graphs/{}".format(self.user_defined_process_id)).json()
+        data = self._connection.get(path="/process_graphs/{}".format(self.user_defined_process_id)).json()
+        return VisualDict('process', data = data)
 
     def delete(self) -> None:
         self._connection.delete(path="/process_graphs/{}".format(self.user_defined_process_id), expected_status=204)

--- a/openeo/rest/udp.py
+++ b/openeo/rest/udp.py
@@ -7,7 +7,7 @@ from openeo.api.process import Parameter
 from openeo.internal.graph_building import as_flat_graph
 from openeo.internal.processes.builder import ProcessBuilderBase
 from openeo.util import dict_no_none
-from openeo.internal.jupyter import VisualDict
+from openeo.internal.jupyter import render_component
 
 if hasattr(typing, 'TYPE_CHECKING') and typing.TYPE_CHECKING:
     # Only import this for type hinting purposes. Runtime import causes circular dependency issues.
@@ -55,7 +55,8 @@ class RESTUserDefinedProcess:
         self._connection = connection
 
     def _repr_html_(self):
-        return self.describe()._repr_html_()
+        process = self.describe()
+        return render_component('process', data = process)
 
     def store(
             self, process_graph: Union[dict, ProcessBuilderBase], parameters: List[Union[Parameter, dict]] = None,
@@ -84,8 +85,7 @@ class RESTUserDefinedProcess:
 
     def describe(self) -> dict:
         # TODO: parse the "parameters" to Parameter objects?
-        data = self._connection.get(path="/process_graphs/{}".format(self.user_defined_process_id)).json()
-        return VisualDict('process', data = data)
+        return self._connection.get(path="/process_graphs/{}".format(self.user_defined_process_id)).json()
 
     def delete(self) -> None:
         self._connection.delete(path="/process_graphs/{}".format(self.user_defined_process_id), expected_status=204)

--- a/openeo/service.py
+++ b/openeo/service.py
@@ -1,24 +1,44 @@
 from abc import ABC
-
+from typing import List
+from openeo.internal.jupyter import VisualDict, VisualList
+from openeo.api.logs import LogEntry
 
 class Service(ABC):
-    """Represents a process graph of openeo."""
+    """Represents a secondary web service in openeo."""
 
-    def __init__(self, service_id):
-        pass
+    def __init__(self, service_id: str, connection: 'Connection'):
+        self.service_id = service_id
+        """Unique identifier of the secondary web service (string)."""
+
+        self.connection = connection
+
+    def __repr__(self):
+        return '<{c} service_id={i!r}>'.format(c=self.__class__.__name__, i=self.service_id)
+
+    def _repr_html_(self):
+        return self.describe_service()._repr_html_()
 
     def describe_service(self):
         """ Get all information about a secondary web service."""
         # GET /services/{service_id}
-        pass
+        data = self.connection.get("/services/{}".format(self.service_id), expected_status=200).json()
+        currency = self.connection.capabilities().currency()
+        return VisualDict('service', data = data, parameters = {'currency': currency})
 
     def update_service(self, process_graph=None, title=None, description=None,
                        enabled=None, parameters=None, plan=None, budget=None):
         """ Update a secondary web service."""
         # PATCH /services/{service_id}
-        pass
+        raise NotImplementedError
 
     def delete_service(self):
         """ Delete a secondary web service."""
         # DELETE /services/{service_id}
-        pass
+        self.connection.delete("/services/{}".format(self.service_id), expected_status=204)
+
+    def logs(self, offset=None) -> List[LogEntry]:
+        """ Retrieve service logs."""
+        url = "/service/{}/logs".format(self.service_id)
+        logs = self.connection.get(url, params={'offset': offset}, expected_status=200).json()["logs"]
+        entries = [LogEntry(log) for log in logs]
+        return VisualList('logs', data = entries)

--- a/tests/rest/datacube/test_datacube.py
+++ b/tests/rest/datacube/test_datacube.py
@@ -17,7 +17,7 @@ from openeo.capabilities import ComparableVersion
 from openeo.rest import BandMathException
 from openeo.rest.datacube import DataCube
 from openeo.rest.imagecollectionclient import ImageCollectionClient
-from openeo.service import Service
+from openeo.rest.service import Service
 from .. import get_download_graph
 from ..conftest import reset_graphbuilder
 from .conftest import API_URL

--- a/tests/rest/datacube/test_datacube.py
+++ b/tests/rest/datacube/test_datacube.py
@@ -412,7 +412,7 @@ def test_tiled_viewing_service(s2cube, connection, requests_mock, api_version):
     )
 
     res = s2cube.tiled_viewing_service(type="WMTS", title="S2 Foo", description="Nice!", custom_param=45)
-    assert res.service_id == Service('sf00', connection).service_id
+    assert res.service_id == 'sf00'
 
 
 def test_apply_dimension(connection, requests_mock):

--- a/tests/rest/datacube/test_datacube.py
+++ b/tests/rest/datacube/test_datacube.py
@@ -17,6 +17,7 @@ from openeo.capabilities import ComparableVersion
 from openeo.rest import BandMathException
 from openeo.rest.datacube import DataCube
 from openeo.rest.imagecollectionclient import ImageCollectionClient
+from openeo.service import Service
 from .. import get_download_graph
 from ..conftest import reset_graphbuilder
 from .conftest import API_URL
@@ -411,7 +412,7 @@ def test_tiled_viewing_service(s2cube, connection, requests_mock, api_version):
     )
 
     res = s2cube.tiled_viewing_service(type="WMTS", title="S2 Foo", description="Nice!", custom_param=45)
-    assert res == {"url": API_URL + "/services/sf00", 'service_id': 'sf00'}
+    assert res.service_id == Service('sf00', connection).service_id
 
 
 def test_apply_dimension(connection, requests_mock):


### PR DESCRIPTION
Adds support for additional Jupyter visualizations:

- UDP list
- UDP details
- Job details
- Job estimates
- Job logs (need help here)
- Show capabilities for Connection class

Not included, although available as components:
- Logs could also be made available for sync. processing, but seems to be unsupported by the Python client yet?
- Service details + logs could also be implemented, but seems to be unsupported by the Python client yet (service.py)?

I still need to deploy to npm, waiting to solve the remaining issues here (see comment) so that I can fully test the components locally afterward.

ToDos:
- [ ] Add CHANGELOG entries
- [x] Release Vue Components 2.1 and wait for CDN to update