### PR TITLE
Jupyter integration for Logs, renamed JobLogEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disallow redirects on POST/DELETE/... requests and require status code 200 on `POST /result` requests. 
   This improves error information where `POST /result` would involve a redirect. (EP-3889)
-- Class `JobLogEntry` got replaced with a more feature-complete and re-usable `LogEntry` class
+- Class `JobLogEntry` got replaced with a more complete and re-usable `LogEntry` dict
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#204](https://github.com/Open-EO/openeo-python-client/issues/204))
 - Add `optional` argument to `Parameter` and fix re-encoding parameters with default value. (EP-3846)
 - Add support to test strict equality with `ComparableVersion`
-- Class `JobLogEntry` got replaced with a more feature-complete and re-usable `LogEntry` class
 - Jupyter integration: add rich HTML rendering for more backend metadata (Job, Job Estimate, Logs, User-Defined Processes)
 
 ### Changed
 
 - Disallow redirects on POST/DELETE/... requests and require status code 200 on `POST /result` requests. 
   This improves error information where `POST /result` would involve a redirect. (EP-3889)
+- Class `JobLogEntry` got replaced with a more feature-complete and re-usable `LogEntry` class
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#204](https://github.com/Open-EO/openeo-python-client/issues/204))
 - Add `optional` argument to `Parameter` and fix re-encoding parameters with default value. (EP-3846)
 - Add support to test strict equality with `ComparableVersion`
+- Jupyter integration: add rich HTML rendering for more backend metadata (Logs)
+- Class `JobLogEntry` got replaced with a more feature-complete and re-usable `LogEntry` class
 
 ### Changed
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,6 +30,9 @@ openeo.api
 .. automodule:: openeo.api.process
     :members: Parameter
 
+.. automodule:: openeo.api.logs
+    :members: LogEntry
+
 
 openeo.rest.connection
 ----------------------
@@ -42,7 +45,7 @@ openeo.rest.job
 ----------------------
 
 .. automodule:: openeo.rest.job
-    :members: RESTJob, JobLogEntry, JobResults, ResultAsset
+    :members: RESTJob, JobResults, ResultAsset
 
 
 openeo.rest.conversions

--- a/openeo/api/logs.py
+++ b/openeo/api/logs.py
@@ -30,10 +30,6 @@ class LogEntry(dict):
         if missing:
             raise ValueError("Missing required fields: {m}".format(m=sorted(missing)))
 
-        # todo: Use native date/time object?
-        self.setdefault("time", None)
-        self.setdefault("links", [])
-
     @property
     def id(self):
         return self["id"]
@@ -48,3 +44,5 @@ class LogEntry(dict):
     @property
     def level(self):
         return self["level"]
+
+    # TODO: add properties for "code", "time", "path", "links" and "data" with sensible defaults?

--- a/openeo/api/logs.py
+++ b/openeo/api/logs.py
@@ -1,5 +1,3 @@
-import json
-
 class LogEntry:
     """
     A log entry.
@@ -20,7 +18,7 @@ class LogEntry:
 
         # Date and time of the error event as RFC3339 date-time, string, available since API 1.1.0
         # todo: Use native date/time object?
-        self.time =  entry.get("time", None)
+        self.time = entry.get("time", None)
 
         # A "stack trace" for the process, array of dicts
         self.path = entry.get("path", [])
@@ -32,7 +30,7 @@ class LogEntry:
         # May contain the following metrics: cpu, memory, duration, network, disk, storage and other custom ones
         # Each of the metrics is also a dict with the following parts: value (numeric) and unit (string)
         self.usage = entry.get("usage", {})
-        
+
         # Arbritrary data the user wants to "log" for debugging purposes.
         # Please note that this property may not exist as there's a difference
         # between None and non-existing. None for example refers to no-data in

--- a/openeo/api/logs.py
+++ b/openeo/api/logs.py
@@ -1,40 +1,34 @@
-class LogEntry:
-    """
-    A log entry.
-    """
+"""
+LogEntry - log messages for jobs and services
 
-    def __init__(self, entry):
-        # Unique ID for the log, string, REQUIRED
-        self.id = entry['id']
+Properties:
+- id: Unique ID for the log, string, REQUIRED
+- code: Error code, string, optional
+- level: Severity level, string (error, warning, info or debug), REQUIRED
+- message: Error message, string, REQUIRED
+- time: Date and time of the error event as RFC3339 date-time, string, available since API 1.1.0
+- path: A "stack trace" for the process, array of dicts
+- links: Related links, array of dicts
+- usage: Usage metrics available as property 'usage', dict, available since API 1.1.0
+  May contain the following metrics: cpu, memory, duration, network, disk, storage and other custom ones
+  Each of the metrics is also a dict with the following parts: value (numeric) and unit (string)
+- data: Arbritrary data the user wants to "log" for debugging purposes.
+  Please note that this property may not exist as there's a difference
+  between None and non-existing. None for example refers to no-data in
+  many cases while the absence of the property means that the user did 
+  not provide any data for debugging.
+"""
 
-        # Error code, string, optional
-        self.code = entry.get("code", "")
+class LogEntry(dict):
 
-        # Severity level, string (error, warning, info or debug), REQUIRED
-        self.level = entry['level']
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-        # Error message, string, REQUIRED
-        self.message = entry['message']
-
-        # Date and time of the error event as RFC3339 date-time, string, available since API 1.1.0
+        # Check required fields
+        missing = self._required.difference(self.keys())
+        if missing:
+            raise ValueError("Missing required fields: {m}".format(m=sorted(missing)))
+        
         # todo: Use native date/time object?
-        self.time = entry.get("time", None)
-
-        # A "stack trace" for the process, array of dicts
-        self.path = entry.get("path", [])
-
-        # Related links, array of dicts
-        self.links = entry.get("links", [])
-
-        # Usage metrics, dict, available since API 1.1.0
-        # May contain the following metrics: cpu, memory, duration, network, disk, storage and other custom ones
-        # Each of the metrics is also a dict with the following parts: value (numeric) and unit (string)
-        self.usage = entry.get("usage", {})
-
-        # Arbritrary data the user wants to "log" for debugging purposes.
-        # Please note that this property may not exist as there's a difference
-        # between None and non-existing. None for example refers to no-data in
-        # many cases while the absence of the property means that the user did 
-        # not provide any data for debugging.
-        if 'data' in entry:
-            self.data = entry['data']
+        self.setdefault("time", None)
+        self.setdefault("links", [])

--- a/openeo/api/logs.py
+++ b/openeo/api/logs.py
@@ -1,0 +1,42 @@
+import json
+
+class LogEntry:
+    """
+    A log entry.
+    """
+
+    def __init__(self, entry):
+        # Unique ID for the log, string, REQUIRED
+        self.id = entry['id']
+
+        # Error code, string, optional
+        self.code = entry.get("code", "")
+
+        # Severity level, string (error, warning, info or debug), REQUIRED
+        self.level = entry['level']
+
+        # Error message, string, REQUIRED
+        self.message = entry['message']
+
+        # Date and time of the error event as RFC3339 date-time, string, available since API 1.1.0
+        # todo: Use native date/time object?
+        self.time =  entry.get("time", None)
+
+        # A "stack trace" for the process, array of dicts
+        self.path = entry.get("path", [])
+
+        # Related links, array of dicts
+        self.links = entry.get("links", [])
+
+        # Usage metrics, dict, available since API 1.1.0
+        # May contain the following metrics: cpu, memory, duration, network, disk, storage and other custom ones
+        # Each of the metrics is also a dict with the following parts: value (numeric) and unit (string)
+        self.usage = entry.get("usage", {})
+        
+        # Arbritrary data the user wants to "log" for debugging purposes.
+        # Please note that this property may not exist as there's a difference
+        # between None and non-existing. None for example refers to no-data in
+        # many cases while the absence of the property means that the user did 
+        # not provide any data for debugging.
+        if 'data' in entry:
+            self.data = entry['data']

--- a/openeo/api/logs.py
+++ b/openeo/api/logs.py
@@ -29,7 +29,22 @@ class LogEntry(dict):
         missing = self._required.difference(self.keys())
         if missing:
             raise ValueError("Missing required fields: {m}".format(m=sorted(missing)))
-        
+
         # todo: Use native date/time object?
         self.setdefault("time", None)
         self.setdefault("links", [])
+
+    @property
+    def id(self):
+        return self["id"]
+
+    # Legacy alias
+    log_id = id
+
+    @property
+    def message(self):
+        return self["message"]
+
+    @property
+    def level(self):
+        return self["level"]

--- a/openeo/api/logs.py
+++ b/openeo/api/logs.py
@@ -1,25 +1,26 @@
-"""
-LogEntry - log messages for jobs and services
-
-Properties:
-- id: Unique ID for the log, string, REQUIRED
-- code: Error code, string, optional
-- level: Severity level, string (error, warning, info or debug), REQUIRED
-- message: Error message, string, REQUIRED
-- time: Date and time of the error event as RFC3339 date-time, string, available since API 1.1.0
-- path: A "stack trace" for the process, array of dicts
-- links: Related links, array of dicts
-- usage: Usage metrics available as property 'usage', dict, available since API 1.1.0
-  May contain the following metrics: cpu, memory, duration, network, disk, storage and other custom ones
-  Each of the metrics is also a dict with the following parts: value (numeric) and unit (string)
-- data: Arbritrary data the user wants to "log" for debugging purposes.
-  Please note that this property may not exist as there's a difference
-  between None and non-existing. None for example refers to no-data in
-  many cases while the absence of the property means that the user did 
-  not provide any data for debugging.
-"""
-
 class LogEntry(dict):
+    """
+    LogEntry - log messages for jobs and services
+
+    Properties:
+    - id: Unique ID for the log, string, REQUIRED
+    - code: Error code, string, optional
+    - level: Severity level, string (error, warning, info or debug), REQUIRED
+    - message: Error message, string, REQUIRED
+    - time: Date and time of the error event as RFC3339 date-time, string, available since API 1.1.0
+    - path: A "stack trace" for the process, array of dicts
+    - links: Related links, array of dicts
+    - usage: Usage metrics available as property 'usage', dict, available since API 1.1.0
+      May contain the following metrics: cpu, memory, duration, network, disk, storage and other custom ones
+      Each of the metrics is also a dict with the following parts: value (numeric) and unit (string)
+    - data: Arbritrary data the user wants to "log" for debugging purposes.
+      Please note that this property may not exist as there's a difference
+      between None and non-existing. None for example refers to no-data in
+      many cases while the absence of the property means that the user did 
+      not provide any data for debugging.
+    """
+
+    _required = {"id", "level", "message"}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/openeo/internal/jupyter.py
+++ b/openeo/internal/jupyter.py
@@ -1,6 +1,5 @@
 import json
 
-from openeo.api.logs import LogEntry
 from openeo.rest import OpenEoApiError
 
 SCRIPT_URL = 'https://cdn.jsdelivr.net/npm/@openeo/vue-components@2/assets/openeo.min.js'
@@ -81,14 +80,7 @@ TABLE_COLUMNS = {
 }
 
 
-class OpenEOJupyterJSONEncoder(json.JSONEncoder):
-    def default(self, o):
-        if isinstance(o, LogEntry):
-            return o.__dict__
-        return super().default(o)
-
-
-def render_component(component: str, data=None, parameters: dict = None):
+def render_component(component: str, data = None, parameters: dict = None):
     parameters = parameters or {}
     # Special handling for batch job results, show either item or collection depending on the data
     if component == "batch-job-result":
@@ -116,7 +108,7 @@ def render_component(component: str, data=None, parameters: dict = None):
     """.format(
         script=SCRIPT_URL,
         component=component,
-        props=OpenEOJupyterJSONEncoder().encode(parameters)
+        props=json.dumps(parameters)
     )
 
 

--- a/openeo/internal/jupyter.py
+++ b/openeo/internal/jupyter.py
@@ -104,7 +104,7 @@ def render_component(component: str, data = None, parameters: dict = {}):
     """.format(
         script = SCRIPT_URL,
         component = component,
-        props = json.dumps(parameters)
+        props = json.dumps(parameters, default = lambda o: o.__dict__) # default parameter added to serialize LogEntry
     )
 
 def render_error(error: OpenEoApiError):

--- a/openeo/internal/jupyter.py
+++ b/openeo/internal/jupyter.py
@@ -1,5 +1,6 @@
 import json
 
+from openeo.api.logs import LogEntry
 from openeo.rest import OpenEoApiError
 
 SCRIPT_URL = 'https://cdn.jsdelivr.net/npm/@openeo/vue-components@2/assets/openeo.min.js'
@@ -80,6 +81,13 @@ TABLE_COLUMNS = {
 }
 
 
+class OpenEOJupyterJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, LogEntry):
+            return o.__dict__
+        return super().default(o)
+
+
 def render_component(component: str, data=None, parameters: dict = None):
     parameters = parameters or {}
     # Special handling for batch job results, show either item or collection depending on the data
@@ -108,7 +116,7 @@ def render_component(component: str, data=None, parameters: dict = None):
     """.format(
         script=SCRIPT_URL,
         component=component,
-        props=json.dumps(parameters, default=lambda o: o.__dict__)  # default parameter added to serialize LogEntry
+        props=OpenEOJupyterJSONEncoder().encode(parameters)
     )
 
 

--- a/openeo/rest/job.py
+++ b/openeo/rest/job.py
@@ -8,10 +8,10 @@ from typing import List, Union, Dict, Optional
 from deprecated.sphinx import deprecated
 from requests import ConnectionError, Response
 
+from openeo.api.logs import LogEntry
 from openeo.internal.jupyter import render_component, render_error, VisualDict, VisualList
 from openeo.rest import OpenEoClientException, JobFailedException, OpenEoApiError
 from openeo.util import ensure_dir
-from openeo.api.logs import LogEntry
 
 if hasattr(typing, 'TYPE_CHECKING') and typing.TYPE_CHECKING:
     # Only import this for type hinting purposes. Runtime import causes circular dependency issues.
@@ -125,7 +125,7 @@ class RESTJob:
         url = "/jobs/{}/logs".format(self.job_id)
         logs = self.connection.get(url, params={'offset': offset}, expected_status=200).json()["logs"]
         entries = [LogEntry(log) for log in logs]
-        return VisualList('logs', data = entries)
+        return VisualList('logs', data=entries)
 
     def run_synchronous(self, outputfile: Union[str, Path, None] = None,
                         print=print, max_poll_interval=60, connection_retry_interval=30) -> 'RESTJob':

--- a/tests/api/test_logs.py
+++ b/tests/api/test_logs.py
@@ -1,0 +1,33 @@
+from openeo.api.logs import LogEntry
+import pytest
+
+
+def test_log_entry_empty():
+    with pytest.raises(ValueError, match="Missing required fields"):
+        _ = LogEntry()
+
+
+def test_log_entry_basic_kwargs():
+    log = LogEntry(id="log01", level="info", message="hello")
+    assert log["id"] == "log01"
+    assert log.id == "log01"
+    assert log["level"] == "info"
+    assert log.level == "info"
+    assert log["message"] == "hello"
+    assert log.message == "hello"
+
+
+def test_log_entry_basic_dict():
+    data = {"id": "log01", "level": "info", "message": "hello"}
+    log = LogEntry(data)
+    assert log["id"] == "log01"
+    assert log.id == "log01"
+    assert log["level"] == "info"
+    assert log.level == "info"
+    assert log["message"] == "hello"
+    assert log.message == "hello"
+
+
+def test_log_entry_legacy():
+    log = LogEntry(id="log01", level="info", message="hello")
+    assert log.log_id == "log01"

--- a/tests/internal/test_jupyter.py
+++ b/tests/internal/test_jupyter.py
@@ -1,0 +1,11 @@
+from openeo.api.logs import LogEntry
+from openeo.internal.jupyter import render_component
+
+
+def test_render_component_logs():
+    entries = [LogEntry({"id": "log-01", "level": "info", "message": "hello"})]
+    html = render_component("logs", data=entries)
+    # TODO: smarter html checks?
+    assert '"id": "log-01"' in html
+    assert '"level": "info"' in html
+    assert '"message": "hello"' in html


### PR DESCRIPTION
Based on #206, which is split into three PRs.

Adds rich HTML rendering for more backend metadata: Logs

Class `JobLogEntry` got replaced with a more feature-complete and re-usable `LogEntry` class.

Here were some open comments regarding the LogEntry class.