### PR TITLE
Add `collection_property` helper to simplify building property filters

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -139,8 +139,10 @@ openeo.processes
 Graph building
 ----------------
 
+Various utilities and helpers to simplify the construction of openEO process graphs.
+
 .. automodule:: openeo.rest.graph_building
-    :members: collection_property
+    :members: collection_property, CollectionProperty
 
 .. automodule:: openeo.internal.graph_building
     :members: PGNode, FlatGraphableMixin

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -136,8 +136,11 @@ openeo.processes
     :members: process
 
 
-openeo.internal
+Graph building
 ----------------
+
+.. automodule:: openeo.rest.graph_building
+    :members: collection_property
 
 .. automodule:: openeo.internal.graph_building
     :members: PGNode, FlatGraphableMixin

--- a/openeo/__init__.py
+++ b/openeo/__init__.py
@@ -14,6 +14,7 @@ class BaseOpenEoException(Exception):
 from openeo._version import __version__
 from openeo.rest.connection import Connection, connect, session
 from openeo.rest.datacube import UDF, DataCube
+from openeo.rest.graph_building import collection_property
 from openeo.rest.job import BatchJob, RESTJob
 
 

--- a/openeo/internal/graph_building.py
+++ b/openeo/internal/graph_building.py
@@ -1,6 +1,9 @@
 """
+Internal openEO process graph building utilities
+''''''''''''''''''''''''''''''''''''''''''''''''''
 
-Functionality for abstracting, building, manipulating and processing openEO process graphs.
+Internal functionality for abstracting, building, manipulating and processing openEO process graphs.
+
 """
 
 from __future__ import annotations

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -1143,7 +1143,9 @@ class Connection(RestApiConnection):
         spatial_extent: Optional[Dict[str, float]] = None,
         temporal_extent: Union[Sequence[InputDate], Parameter, str, None] = None,
         bands: Union[None, List[str], Parameter] = None,
-        properties: Union[None, Dict[str, Union[str, PGNode, Callable]], List[CollectionProperty]] = None,
+        properties: Union[
+            None, Dict[str, Union[str, PGNode, Callable]], List[CollectionProperty], CollectionProperty
+        ] = None,
         max_cloud_cover: Optional[float] = None,
         fetch_metadata=True,
     ) -> DataCube:

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -52,6 +52,7 @@ from openeo.rest.auth.oidc import (
     OidcResourceOwnerPasswordAuthenticator,
 )
 from openeo.rest.datacube import DataCube, InputDate
+from openeo.rest.graph_building import CollectionProperty
 from openeo.rest.job import BatchJob, RESTJob
 from openeo.rest.mlmodel import MlModel
 from openeo.rest.rest_capabilities import RESTCapabilities
@@ -1142,7 +1143,7 @@ class Connection(RestApiConnection):
         spatial_extent: Optional[Dict[str, float]] = None,
         temporal_extent: Union[Sequence[InputDate], Parameter, str, None] = None,
         bands: Union[None, List[str], Parameter] = None,
-        properties: Optional[Dict[str, Union[str, PGNode, Callable]]] = None,
+        properties: Union[None, Dict[str, Union[str, PGNode, Callable]], List[CollectionProperty]] = None,
         max_cloud_cover: Optional[float] = None,
         fetch_metadata=True,
     ) -> DataCube:
@@ -1154,8 +1155,9 @@ class Connection(RestApiConnection):
         :param temporal_extent: limit data to specified temporal interval.
             Typically, just a two-item list or tuple containing start and end date.
             See :ref:`filtering-on-temporal-extent-section` for more details on temporal extent handling and shorthand notation.
-        :param bands: only add the specified bands
-        :param properties: limit data by metadata property predicates
+        :param bands: only add the specified bands.
+        :param properties: limit data by collection metadata property predicates.
+            See :py:func:`~openeo.rest.graph_building.collection_property` for easy construction of such predicates.
         :param max_cloud_cover: shortcut to set maximum cloud cover ("eo:cloud_cover" collection property)
         :return: a datacube containing the requested data
 
@@ -1165,6 +1167,9 @@ class Connection(RestApiConnection):
         .. versionchanged:: 0.23.0
             Argument ``temporal_extent``: add support for year/month shorthand notation
             as discussed at :ref:`date-shorthand-handling`.
+
+        .. versionchanged:: 0.26.0
+            Add :py:func:`~openeo.rest.graph_building.collection_property` support to ``properties`` argument.
         """
         return DataCube.load_collection(
             collection_id=collection_id,

--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -125,7 +125,9 @@ class DataCube(_ProcessGraphAbstraction):
         temporal_extent: Union[Sequence[InputDate], Parameter, str, None] = None,
         bands: Union[None, List[str], Parameter] = None,
         fetch_metadata: bool = True,
-        properties: Union[None, Dict[str, Union[str, PGNode, typing.Callable]], List[CollectionProperty]] = None,
+        properties: Union[
+            None, Dict[str, Union[str, PGNode, typing.Callable]], List[CollectionProperty], CollectionProperty
+        ] = None,
         max_cloud_cover: Optional[float] = None,
     ) -> DataCube:
         """
@@ -176,6 +178,8 @@ class DataCube(_ProcessGraphAbstraction):
         if isinstance(properties, list):
             # TODO: warn about items that are not CollectionProperty objects instead of silently dropping them.
             properties = {p.name: p.from_node() for p in properties if isinstance(p, CollectionProperty)}
+        if isinstance(properties, CollectionProperty):
+            properties = {properties.name: properties.from_node()}
         elif properties is None:
             properties = {}
         if max_cloud_cover:

--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -151,6 +151,9 @@ class DataCube(_ProcessGraphAbstraction):
         .. versionchanged:: 0.23.0
             Argument ``temporal_extent``: add support for year/month shorthand notation
             as discussed at :ref:`date-shorthand-handling`.
+
+        .. versionchanged:: 0.26.0
+            Add :py:func:`~openeo.rest.graph_building.collection_property` support to ``properties`` argument.
         """
         if temporal_extent:
             temporal_extent = cls._get_temporal_extent(extent=temporal_extent)

--- a/openeo/rest/graph_building.py
+++ b/openeo/rest/graph_building.py
@@ -70,7 +70,7 @@ def collection_property(name: str) -> CollectionProperty:
 
     .. versionadded:: 0.26.0
 
-    :param name: name of the property to filter on
+    :param name: name of the collection property to filter on
     :return: an object that supports operators like ``<=``, ``==`` to easily build simple property filters.
     """
     return CollectionProperty(name=name)

--- a/openeo/rest/graph_building.py
+++ b/openeo/rest/graph_building.py
@@ -11,6 +11,15 @@ from openeo.processes import ProcessBuilder
 
 
 class CollectionProperty(_FromNodeMixin):
+    """
+    Helper object to easily create simple collection metadata property filters
+    to be used with :py:meth:`Connection.load_collection() <openeo.rest.connection.Connection.load_collection>`.
+
+    .. note:: This class should not be used directly by end user code.
+        Use the :py:func:`~openeo.rest.graph_building.collection_property` factory instead.
+
+    .. warning:: this is an experimental feature, naming might change.
+    """
     def __init__(self, name: str, _builder: Optional[ProcessBuilder] = None):
         self.name = name
         self._builder = _builder or ProcessBuilder(pgnode={"from_parameter": "value"})
@@ -39,11 +48,15 @@ class CollectionProperty(_FromNodeMixin):
 
 def collection_property(name: str) -> CollectionProperty:
     """
-    Helper to easily create simple a `load_collection` property filter.
+    Helper to easily create simple collection metadata property filters
+    to be used with :py:meth:`Connection.load_collection() <openeo.rest.connection.Connection.load_collection>`.
 
     Usage example:
 
     .. code-block:: python
+
+        from openeo import collection_property
+        ...
 
         connection.load_collection(
             ...
@@ -53,7 +66,11 @@ def collection_property(name: str) -> CollectionProperty:
             ]
         )
 
+    .. warning:: this is an experimental feature, naming might change.
+
+    .. versionadded:: 0.26.0
+
     :param name: name of the property to filter on
-    :return: an object which supports operators like ``<=``, ``==`` to build a simple property filter.
+    :return: an object that supports operators like ``<=``, ``==`` to easily build simple property filters.
     """
     return CollectionProperty(name=name)

--- a/openeo/rest/graph_building.py
+++ b/openeo/rest/graph_building.py
@@ -1,0 +1,59 @@
+"""
+Public openEO process graph building utilities
+'''''''''''''''''''''''''''''''''''''''''''''''
+
+"""
+
+from typing import Optional
+
+from openeo.internal.graph_building import PGNode, _FromNodeMixin
+from openeo.processes import ProcessBuilder
+
+
+class CollectionProperty(_FromNodeMixin):
+    def __init__(self, name: str, _builder: Optional[ProcessBuilder] = None):
+        self.name = name
+        self._builder = _builder or ProcessBuilder(pgnode={"from_parameter": "value"})
+
+    def from_node(self) -> PGNode:
+        return self._builder.from_node()
+
+    def __eq__(self, other):
+        return CollectionProperty(self.name, _builder=self._builder == other)
+
+    def __ne__(self, other):
+        return CollectionProperty(self.name, _builder=self._builder != other)
+
+    def __gt__(self, other):
+        return CollectionProperty(self.name, _builder=self._builder > other)
+
+    def __ge__(self, other):
+        return CollectionProperty(self.name, _builder=self._builder >= other)
+
+    def __lt__(self, other):
+        return CollectionProperty(self.name, _builder=self._builder < other)
+
+    def __le__(self, other):
+        return CollectionProperty(self.name, _builder=self._builder <= other)
+
+
+def collection_property(name: str) -> CollectionProperty:
+    """
+    Helper to easily create simple a `load_collection` property filter.
+
+    Usage example:
+
+    .. code-block:: python
+
+        connection.load_collection(
+            ...
+            properties=[
+                collection_property("eo:cloud_cover") <= 75,
+                collection_property("platform") == "Sentinel-2B",
+            ]
+        )
+
+    :param name: name of the property to filter on
+    :return: an object which supports operators like ``<=``, ``==`` to build a simple property filter.
+    """
+    return CollectionProperty(name=name)

--- a/openeo/rest/graph_building.py
+++ b/openeo/rest/graph_building.py
@@ -3,7 +3,7 @@ Public openEO process graph building utilities
 '''''''''''''''''''''''''''''''''''''''''''''''
 
 """
-
+from __future__ import annotations
 from typing import Optional
 
 from openeo.internal.graph_building import PGNode, _FromNodeMixin
@@ -27,22 +27,22 @@ class CollectionProperty(_FromNodeMixin):
     def from_node(self) -> PGNode:
         return self._builder.from_node()
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> CollectionProperty:
         return CollectionProperty(self.name, _builder=self._builder == other)
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> CollectionProperty:
         return CollectionProperty(self.name, _builder=self._builder != other)
 
-    def __gt__(self, other):
+    def __gt__(self, other) -> CollectionProperty:
         return CollectionProperty(self.name, _builder=self._builder > other)
 
-    def __ge__(self, other):
+    def __ge__(self, other) -> CollectionProperty:
         return CollectionProperty(self.name, _builder=self._builder >= other)
 
-    def __lt__(self, other):
+    def __lt__(self, other) -> CollectionProperty:
         return CollectionProperty(self.name, _builder=self._builder < other)
 
-    def __le__(self, other):
+    def __le__(self, other) -> CollectionProperty:
         return CollectionProperty(self.name, _builder=self._builder <= other)
 
 

--- a/tests/rest/datacube/test_datacube100.py
+++ b/tests/rest/datacube/test_datacube100.py
@@ -1647,19 +1647,95 @@ def test_load_collection_max_cloud_cover_summaries_warning(
 
 
 def test_load_collection_with_collection_properties(con100):
-    im = con100.load_collection(
+    cube = con100.load_collection(
         "S2",
         properties=[
             collection_property("eo:cloud_cover") <= 75,
             collection_property("platform") == "Sentinel-2B",
         ],
     )
-    assert im.flat_graph()["loadcollection1"]["arguments"]["properties"] == {
+    assert cube.flat_graph()["loadcollection1"]["arguments"]["properties"] == {
         "eo:cloud_cover": {
             "process_graph": {
                 "lte1": {
                     "process_id": "lte",
                     "arguments": {"x": {"from_parameter": "value"}, "y": 75},
+                    "result": True,
+                }
+            }
+        },
+        "platform": {
+            "process_graph": {
+                "eq1": {
+                    "process_id": "eq",
+                    "arguments": {"x": {"from_parameter": "value"}, "y": "Sentinel-2B"},
+                    "result": True,
+                }
+            }
+        },
+    }
+
+
+def test_load_collection_with_collection_properties_and_cloud_cover(con100):
+    cube = con100.load_collection(
+        "S2",
+        properties=[
+            collection_property("platform") == "Sentinel-2B",
+        ],
+        max_cloud_cover=66,
+    )
+    assert cube.flat_graph()["loadcollection1"]["arguments"]["properties"] == {
+        "eo:cloud_cover": {
+            "process_graph": {
+                "lte1": {
+                    "process_id": "lte",
+                    "arguments": {"x": {"from_parameter": "value"}, "y": 66},
+                    "result": True,
+                }
+            }
+        },
+        "platform": {
+            "process_graph": {
+                "eq1": {
+                    "process_id": "eq",
+                    "arguments": {"x": {"from_parameter": "value"}, "y": "Sentinel-2B"},
+                    "result": True,
+                }
+            }
+        },
+    }
+
+
+def test_load_collection_with_single_collection_property(con100):
+    cube = con100.load_collection(
+        "S2",
+        properties=collection_property("platform") == "Sentinel-2B",
+    )
+    assert cube.flat_graph()["loadcollection1"]["arguments"]["properties"] == {
+        "platform": {
+            "process_graph": {
+                "eq1": {
+                    "process_id": "eq",
+                    "arguments": {"x": {"from_parameter": "value"}, "y": "Sentinel-2B"},
+                    "result": True,
+                }
+            }
+        },
+    }
+
+
+def test_load_collection_with_single_collection_property_and_cloud_cover(con100):
+    cube = con100.load_collection(
+        "S2",
+        properties=collection_property("platform") == "Sentinel-2B",
+        max_cloud_cover=66,
+    )
+    assert cube.flat_graph()["loadcollection1"]["arguments"]["properties"] == {
+        "eo:cloud_cover": {
+            "process_graph": {
+                "lte1": {
+                    "process_id": "lte",
+                    "arguments": {"x": {"from_parameter": "value"}, "y": 66},
                     "result": True,
                 }
             }

--- a/tests/rest/datacube/test_datacube100.py
+++ b/tests/rest/datacube/test_datacube100.py
@@ -20,6 +20,7 @@ import shapely.geometry
 
 import openeo.metadata
 import openeo.processes
+from openeo import collection_property
 from openeo.api.process import Parameter
 from openeo.capabilities import ComparableVersion
 from openeo.internal.graph_building import PGNode
@@ -1643,6 +1644,36 @@ def test_load_collection_max_cloud_cover_summaries_warning(
         )
     else:
         assert len(recwarn.list) == 0
+
+
+def test_load_collection_with_collection_properties(con100):
+    im = con100.load_collection(
+        "S2",
+        properties=[
+            collection_property("eo:cloud_cover") <= 75,
+            collection_property("platform") == "Sentinel-2B",
+        ],
+    )
+    assert im.flat_graph()["loadcollection1"]["arguments"]["properties"] == {
+        "eo:cloud_cover": {
+            "process_graph": {
+                "lte1": {
+                    "process_id": "lte",
+                    "arguments": {"x": {"from_parameter": "value"}, "y": 75},
+                    "result": True,
+                }
+            }
+        },
+        "platform": {
+            "process_graph": {
+                "eq1": {
+                    "process_id": "eq",
+                    "arguments": {"x": {"from_parameter": "value"}, "y": "Sentinel-2B"},
+                    "result": True,
+                }
+            }
+        },
+    }
 
 
 def test_load_collection_temporal_extent_process_builder_function(con100):


### PR DESCRIPTION
While working on #328, I thought of this proof of concept to simplify specifying simple collection property filters.

Usage example:

```python
from openeo import collection_property

cube = con100.load_collection(
    "S2",
    properties=[
        collection_property("eo:cloud_cover") <= 75,
        collection_property("platform") == "Sentinel-2B",
    ]
)
```

note that `properties` is now a list (instead of a dictionary),
containing these `collection_property` operator tricks that are translated to the proper process graphs

