### PR TITLE
Jupyter integration: Visualization for DataCube #336

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Jupyter integration: Visual rendering for data cubes (process graphs) shown instead of a object information.  ([#336](https://github.com/Open-EO/openeo-python-client/issues/336))
+
 ### Changed
 
 ### Removed

--- a/openeo/internal/jupyter.py
+++ b/openeo/internal/jupyter.py
@@ -11,6 +11,7 @@ COMPONENT_MAP = {
     'file-formats': 'formats',
     'item': 'data',
     'job-estimate': 'estimate',
+    'model-builder': 'value',
     'service-type': 'service',
     'service-types': 'services',
     'udf-runtime': 'runtime',

--- a/openeo/rest/_datacube.py
+++ b/openeo/rest/_datacube.py
@@ -4,9 +4,11 @@ import sys
 import typing
 from pathlib import Path
 from typing import Optional, Union, Tuple
+import uuid
 
 from openeo.internal.compat import nullcontext
 from openeo.internal.graph_building import PGNode, _FromNodeMixin
+from openeo.internal.jupyter import render_component
 
 if typing.TYPE_CHECKING:
     # Imports for type checking only (circular import issue at runtime).
@@ -124,3 +126,12 @@ class _ProcessGraphAbstraction(_FromNodeMixin):
         return PGNode(process_id=process_id, arguments=arguments, namespace=namespace)
 
     # TODO #278 also move process graph "execution" methods here: `download`, `execute`, `execute_batch`, `create_job`, `save_udf`,  ...
+
+    def _repr_html_(self):
+        process = {"process_graph": self.flat_graph()}
+        parameters = {
+            'id': uuid.uuid4().hex,
+            'explicit-zoom': True,
+            'height': '400px'
+        }
+        return render_component('model-builder', data = process, parameters = parameters)


### PR DESCRIPTION
Implements #336

Requires v2.11.0 of the Vue components, which will get deployed in the next 24 hours to the CDN.

Example:
![image](https://user-images.githubusercontent.com/8262166/198335736-65719fff-eb1c-4262-b355-7abbde6e3d49.png)
