### PR TITLE
Issue352 execute batch skip 502 bad gateway errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- execute_batch also skips temporal 502 Bad Gateway errors. [#352](https://github.com/Open-EO/openeo-python-client/issues/352)
+
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- execute_batch also skips temporal 502 Bad Gateway errors. [#352](https://github.com/Open-EO/openeo-python-client/issues/352)
+- `execute_batch` also skips temporal `502 Bad Gateway errors`. [#352](https://github.com/Open-EO/openeo-python-client/issues/352)
 
 ### Removed
 

--- a/openeo/rest/job.py
+++ b/openeo/rest/job.py
@@ -207,7 +207,7 @@ class BatchJob:
                 soft_error("Connection error while polling job status: {e}".format(e=e))
                 continue
             except OpenEoApiError as e:
-                if e.http_status_code == 503:
+                if e.http_status_code in [502, 503]:
                     soft_error("Service availability error while polling job status: {e}".format(e=e))
                     continue
                 else:

--- a/tests/rest/test_job.py
+++ b/tests/rest/test_job.py
@@ -151,6 +151,10 @@ def test_execute_batch_with_error(con100, requests_mock, tmpdir):
             },
             "Service availability error while polling job status: [503] OidcProviderUnavailable: OIDC Provider is unavailable",
     ),
+    (
+            {"status_code": 502, "text": "Bad Gateway"},
+            "Service availability error while polling job status: [502] unknown: Bad Gateway",
+    ),
 ])
 def test_execute_batch_with_soft_errors(con100, requests_mock, tmpdir, error_response, expected):
     requests_mock.get(API_URL + "/file_formats", json={"output": {"GTiff": {"gis_data_types": ["raster"]}}})

--- a/tests/rest/test_job.py
+++ b/tests/rest/test_job.py
@@ -209,6 +209,10 @@ def test_execute_batch_with_soft_errors(con100, requests_mock, tmpdir, error_res
             },
             "Service availability error while polling job status: [503] OidcProviderUnavailable: OIDC Provider is unavailable",
     ),
+    (
+            {"status_code": 502, "text": "Bad Gateway"},
+            "Service availability error while polling job status: [502] unknown: Bad Gateway",
+    ),
 ])
 def test_execute_batch_with_excessive_soft_errors(con100, requests_mock, tmpdir, error_response, expected):
     requests_mock.get(API_URL + "/file_formats", json={"output": {"GTiff": {"gis_data_types": ["raster"]}}})


### PR DESCRIPTION
This implements issue [#352](https://github.com/Open-EO/openeo-python-client/issues/352)


