### PR TITLE
pre-commit config: Upgrade darker to version that avoids bug in black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,6 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/akaihola/darker
-    rev: 1.5.1
+    rev: 1.6.1
     hooks:
       - id: darker


### PR DESCRIPTION
Now that the [darker](https://github.com/akaihola/darker) 1.6 has been released it might be a good time to update the pre-commit config file.

Previously we needed to pin [black ](https://github.com/psf/black) to an older version because of a bug : https://github.com/akaihola/darker/issues/403

With darker 1.6.1 that problem should be solved.
