### PR TITLE
Support for the /files endpoints #377

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The openeo Python client library can now also be installed with conda (conda-forge channel)
   ([#176](https://github.com/Open-EO/openeo-python-client/issues/176))
 - Allow using a custom `requests.Session` in `openeo.rest.auth.oidc` logic
-- Full support for user-uploaded files (`/files` endpoints) [#377](https://github.com/Open-EO/openeo-python-client/issues/377)
+- Full support for user-uploaded files (`/files` endpoints)
+  ([#377](https://github.com/Open-EO/openeo-python-client/issues/377))
 
 ### Changed
 
 - Less verbose log printing on failed batch job [#332](https://github.com/Open-EO/openeo-python-client/issues/332)
 - Improve (UTC) timezone handling in `openeo.util.Rfc3339` and add `rfc3339.today()`/`rfc3339.utcnow()`.
-- `list_files()` returns a list of `UserFile` objects instead of a list of dictionaries - use `to_dict` on the `UserFile` object to get the dictionary.
+- `Connection.list_files()` returns a list of `UserFile` objects instead of a list of metadata dictionaries.
+  Use `UserFile.metadata` to get the original dictionary.
+  ([#377](https://github.com/Open-EO/openeo-python-client/issues/377))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The openeo Python client library can now also be installed with conda (conda-forge channel)
   ([#176](https://github.com/Open-EO/openeo-python-client/issues/176))
 - Allow using a custom `requests.Session` in `openeo.rest.auth.oidc` logic
+- Full support for user-uploaded files (`/files` endpoints) [#377](https://github.com/Open-EO/openeo-python-client/issues/377)
 
 ### Changed
 
 - Less verbose log printing on failed batch job [#332](https://github.com/Open-EO/openeo-python-client/issues/332)
 - Improve (UTC) timezone handling in `openeo.util.Rfc3339` and add `rfc3339.today()`/`rfc3339.utcnow()`.
+- `list_files()` returns a list of `UserFile` objects instead of a list of dictionaries - use `to_dict` on the `UserFile` object to get the dictionary.
 
 ### Removed
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -86,6 +86,13 @@ openeo.rest.udp
     :members: RESTUserDefinedProcess
 
 
+openeo.rest.userfile
+----------------------
+
+.. automodule:: openeo.rest.userfile
+    :members:
+
+
 openeo.udf
 -------------
 

--- a/openeo/internal/jupyter.py
+++ b/openeo/internal/jupyter.py
@@ -102,6 +102,8 @@ def render_component(component: str, data = None, parameters: dict = None):
     # Set the data as the corresponding parameter in the Vue components
     key = COMPONENT_MAP.get(component, component)
     if data is not None:
+        if isinstance(data, list):
+            data = [(x.to_dict() if "to_dict" in dir(x) else x) for x in data]
         parameters[key] = data
 
     # Construct HTML, load Vue Components source files only if the openEO HTML tag is not yet defined

--- a/openeo/internal/jupyter.py
+++ b/openeo/internal/jupyter.py
@@ -103,7 +103,7 @@ def render_component(component: str, data = None, parameters: dict = None):
     key = COMPONENT_MAP.get(component, component)
     if data is not None:
         if isinstance(data, list):
-            data = [(x.to_dict() if "to_dict" in dir(x) else x) for x in data]
+            data = [(x.to_dict() if hasattr(x, "to_dict") else x) for x in data]
         parameters[key] = data
 
     # Construct HTML, load Vue Components source files only if the openEO HTML tag is not yet defined

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -1089,9 +1089,9 @@ class Connection(RestApiConnection):
         """Get batch job logs."""
         return BatchJob(job_id=job_id, connection=self).logs(offset=offset)
 
-    def list_files(self):
+    def list_files(self) -> List[UserFile]:
         """
-        Lists all files that the logged in user uploaded.
+        Lists all files that the logged-in user uploaded.
 
         :return: file_list: List of the user-uploaded files.
         """
@@ -1100,16 +1100,20 @@ class Connection(RestApiConnection):
         files = [UserFile(file['path'], connection=self, metadata=file) for file in files]
         return VisualList("data-table", data=files, parameters={'columns': 'files'})
 
-    def get_file(self, path: str) -> UserFile:
+    def get_file(self, path: Union[str, PurePosixPath]) -> UserFile:
         """
         Gets a handle to a file in the user workspace on the back-end.
 
-        :param path: The  path on the user workspace.
+        :param path: The path on the user workspace.
         :return: UserFile object.
         """
         return UserFile(path, connection=self)
 
-    def upload_file(self, source: Union[Path, str], target: str = None) -> UserFile:
+    def upload_file(
+        self,
+        source: Union[Path, str],
+        target: Optional[Union[str, PurePosixPath]] = None,
+    ) -> UserFile:
         """
         Uploads a file to the given target location in the user workspace.
 
@@ -1120,7 +1124,7 @@ class Connection(RestApiConnection):
         :return: UserFile object.
         """
         if target is None:
-            target = PurePosixPath(source).name
+            target = Path(source).name
         return self.get_file(target).upload(source)
 
     def _build_request_with_process_graph(self, process_graph: Union[dict, Any], **kwargs) -> dict:

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -33,6 +33,7 @@ from openeo.rest.auth.oidc import OidcClientCredentialsAuthenticator, OidcAuthCo
 from openeo.rest.datacube import DataCube
 from openeo.rest.imagecollectionclient import ImageCollectionClient
 from openeo.rest.mlmodel import MlModel
+from openeo.rest.userfile import UserFile
 from openeo.rest.job import BatchJob, RESTJob
 from openeo.rest.rest_capabilities import RESTCapabilities
 from openeo.rest.service import Service
@@ -1092,20 +1093,20 @@ class Connection(RestApiConnection):
         """
         Lists all files that the logged in user uploaded.
 
-        :return: file_list: List of the user uploaded files.
+        :return: file_list: List of the user-uploaded files.
         """
 
         files = self.get('/files', expected_status=200).json()['files']
+        files = [UserFile(file['path'], self, file) for file in files]
         return VisualList("data-table", data=files, parameters={'columns': 'files'})
 
-    def create_file(self, path):
+    def get_file(self, path) -> UserFile:
         """
-        Creates virtual file
+        Gets a (virtual) file for the user workspace
 
-        :return: file object.
+        :return: UserFile object.
         """
-        # No endpoint just returns a file object.
-        raise NotImplementedError()
+        return UserFile(path, self)
 
     def _build_request_with_process_graph(self, process_graph: Union[dict, Any], **kwargs) -> dict:
         """

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -5,7 +5,6 @@ import datetime
 import json
 import logging
 import shlex
-import os
 import sys
 import warnings
 from collections import OrderedDict
@@ -1103,7 +1102,7 @@ class Connection(RestApiConnection):
 
     def get_file(self, path: str) -> UserFile:
         """
-        Gets a (virtual) file for the user workspace
+        Gets a handle to a file in the user workspace on the back-end.
 
         :return: UserFile object.
         """
@@ -1116,7 +1115,7 @@ class Connection(RestApiConnection):
 
         :return: UserFile object.
         """
-        return self.get_file(os.path.basename(source)).upload(source)
+        return self.get_file(Path(source).name).upload(source)
 
     def _build_request_with_process_graph(self, process_graph: Union[dict, Any], **kwargs) -> dict:
         """

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -1091,11 +1091,10 @@ class Connection(RestApiConnection):
 
     def list_files(self) -> List[UserFile]:
         """
-        Lists all files that the logged-in user uploaded.
+        Lists all user-uploaded files in the user workspace on the back-end.
 
-        :return: file_list: List of the user-uploaded files.
+        :return: List of the user-uploaded files.
         """
-
         files = self.get('/files', expected_status=200).json()['files']
         files = [UserFile.from_metadata(metadata=f, connection=self) for f in files]
         return VisualList("data-table", data=files, parameters={'columns': 'files'})
@@ -1104,10 +1103,9 @@ class Connection(RestApiConnection):
         self, path: Union[str, PurePosixPath], metadata: Optional[dict] = None
     ) -> UserFile:
         """
-        Gets a handle to a file in the user workspace on the back-end.
+        Gets a handle to a user-uploaded file in the user workspace on the back-end.
 
         :param path: The path on the user workspace.
-        :return: UserFile object.
         """
         return UserFile(path=path, connection=self, metadata=metadata)
 
@@ -1117,13 +1115,13 @@ class Connection(RestApiConnection):
         target: Optional[Union[str, PurePosixPath]] = None,
     ) -> UserFile:
         """
-        Uploads a file to the given target location in the user workspace.
+        Uploads a file to the given target location in the user workspace on the back-end.
 
         If a file at the target path exists in the user workspace it will be replaced.
 
         :param source: A path to a file on the local file system to upload.
-        :param target: The desired path on the user workspace. If not set, defaults to the filename (without path) of the local file.
-        :return: UserFile object.
+        :param target: The desired path on the user workspace.
+            If not set, defaults to the filename (without path) of the local file.
         """
         source = Path(source)
         target = target or source.name

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -1097,7 +1097,7 @@ class Connection(RestApiConnection):
         """
 
         files = self.get('/files', expected_status=200).json()['files']
-        files = [UserFile(file['path'], self, file) for file in files]
+        files = [UserFile(file['path'], connection=self, metadata=file) for file in files]
         return VisualList("data-table", data=files, parameters={'columns': 'files'})
 
     def get_file(self, path) -> UserFile:
@@ -1106,7 +1106,7 @@ class Connection(RestApiConnection):
 
         :return: UserFile object.
         """
-        return UserFile(path, self)
+        return UserFile(path, connection=self)
 
     def _build_request_with_process_graph(self, process_graph: Union[dict, Any], **kwargs) -> dict:
         """

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -5,6 +5,7 @@ import datetime
 import json
 import logging
 import shlex
+import os
 import sys
 import warnings
 from collections import OrderedDict
@@ -1100,13 +1101,22 @@ class Connection(RestApiConnection):
         files = [UserFile(file['path'], connection=self, metadata=file) for file in files]
         return VisualList("data-table", data=files, parameters={'columns': 'files'})
 
-    def get_file(self, path) -> UserFile:
+    def get_file(self, path: str) -> UserFile:
         """
         Gets a (virtual) file for the user workspace
 
         :return: UserFile object.
         """
         return UserFile(path, connection=self)
+
+    def upload_file(self, source: Union[Path, str]) -> UserFile:
+        """
+        Uploads a file to the user workspace and stores it with the filename of the source given.
+        If a file with the name exists on the user workspace it will be replaced.
+
+        :return: UserFile object.
+        """
+        return self.get_file(os.path.basename(source)).upload(source)
 
     def _build_request_with_process_graph(self, process_graph: Union[dict, Any], **kwargs) -> dict:
         """

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -1120,8 +1120,8 @@ class Connection(RestApiConnection):
         If a file at the target path exists in the user workspace it will be replaced.
 
         :param source: A path to a file on the local file system to upload.
-        :param target: The desired path on the user workspace.
-            If not set, defaults to the filename (without path) of the local file.
+        :param target: The desired path (which can contain a folder structure if desired) on the user workspace.
+            If not set: defaults to the original filename (without any folder structure) of the local file .
         """
         source = Path(source)
         target = target or source.name

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -8,7 +8,7 @@ import shlex
 import sys
 import warnings
 from collections import OrderedDict
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Dict, List, Tuple, Union, Callable, Optional, Any, Iterator
 from urllib.parse import urljoin
 
@@ -1120,7 +1120,7 @@ class Connection(RestApiConnection):
         :return: UserFile object.
         """
         if target is None:
-            target = Path(source).name
+            target = PurePosixPath(source).name
         return self.get_file(target).upload(source)
 
     def _build_request_with_process_graph(self, process_graph: Union[dict, Any], **kwargs) -> dict:

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -1104,18 +1104,24 @@ class Connection(RestApiConnection):
         """
         Gets a handle to a file in the user workspace on the back-end.
 
+        :param path: The  path on the user workspace.
         :return: UserFile object.
         """
         return UserFile(path, connection=self)
 
-    def upload_file(self, source: Union[Path, str]) -> UserFile:
+    def upload_file(self, source: Union[Path, str], target: str = None) -> UserFile:
         """
-        Uploads a file to the user workspace and stores it with the filename of the source given.
-        If a file with the name exists on the user workspace it will be replaced.
+        Uploads a file to the given target location in the user workspace.
 
+        If a file at the target path exists in the user workspace it will be replaced.
+
+        :param source: A path to a file on the local file system to upload.
+        :param target: The desired path on the user workspace. If not set, defaults to the filename (without path) of the local file.
         :return: UserFile object.
         """
-        return self.get_file(Path(source).name).upload(source)
+        if target is None:
+            target = Path(source).name
+        return self.get_file(target).upload(source)
 
     def _build_request_with_process_graph(self, process_graph: Union[dict, Any], **kwargs) -> dict:
         """

--- a/openeo/rest/userfile.py
+++ b/openeo/rest/userfile.py
@@ -1,0 +1,58 @@
+import typing
+from typing import Any, Dict, List, Union
+from pathlib import Path
+
+if typing.TYPE_CHECKING:
+    # Imports for type checking only (circular import issue at runtime).
+    from openeo.rest.connection import Connection
+
+
+class UserFile:
+    """Represents a file in the user-workspace of openeo."""
+
+    def __init__(self, path: str, connection: 'Connection', metadata: Dict[str, Any] = {}):
+        self.path = path
+        self.metadata = metadata
+        self.connection = connection
+
+    def __repr__(self):
+        return '<{c} file={i!r}>'.format(c=self.__class__.__name__, i=self.path)
+
+    def _get_endpoint(self) -> str:
+        return "/files/{}".format(self.path)
+
+    def get_metadata(self, key) -> Any:
+        """ Get metadata about the file, e.g. file size (key: 'size') or modification date (key: 'modified')."""
+        if key in self.metadata:
+            return self.metadata[key]
+        else:
+            return None
+
+    def download_file(self, target: Union[Path, str]) -> Path:
+        """ Downloads a user-uploaded file."""
+        # GET /files/{path}
+        response = self.connection.get(self._get_endpoint(), expected_status=200, stream=True)
+
+        path = Path(target)
+        with path.open(mode="wb") as f:
+            for chunk in response.iter_content(chunk_size=None):
+                f.write(chunk)
+
+        return path
+
+
+    def upload_file(self, source: Union[Path, str]):
+        # PUT /files/{path}
+        """ Uploaded (or replaces) a user-uploaded file."""
+        path = Path(source)
+        with path.open(mode="rb") as f:
+            self.connection.put(self._get_endpoint(), expected_status=200, data=f)
+
+    def delete_file(self):
+        """ Delete a user-uploaded file."""
+        # DELETE /files/{path}
+        self.connection.delete(self._get_endpoint(), expected_status=204)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """ Returns the provided metadata as dict."""
+        return self.metadata if "path" in self.metadata else {"path": self.path}

--- a/openeo/rest/userfile.py
+++ b/openeo/rest/userfile.py
@@ -1,6 +1,5 @@
 import typing
 from typing import Any, Dict, Union
-import os
 from pathlib import Path
 from openeo.util import ensure_dir
 
@@ -13,7 +12,7 @@ class UserFile:
     """Represents a file in the user-workspace of openeo."""
 
     def __init__(self, path: str, connection: 'Connection', metadata: Dict[str, Any] = None):
-        self.path = path
+        self.path = Path(path)
         self.metadata = metadata or {"path": path}
         self.connection = connection
 
@@ -21,7 +20,7 @@ class UserFile:
         return '<{c} file={i!r}>'.format(c=self.__class__.__name__, i=self.path)
 
     def _get_endpoint(self) -> str:
-        return "/files/{}".format(self.path)
+        return f"/files/{self.path!s}"
 
     def download(self, target: Union[Path, str] = None) -> Path:
         """
@@ -36,7 +35,7 @@ class UserFile:
 
         target = Path(target or Path.cwd()) 
         if target.is_dir():
-            target = target / os.path.basename(self.path)
+            target = target / self.path.name
         ensure_dir(target.parent)
         
         with target.open(mode="wb") as f:

--- a/openeo/rest/userfile.py
+++ b/openeo/rest/userfile.py
@@ -43,11 +43,16 @@ class UserFile:
                 f.write(chunk)
 
         return target
+    
+    def upload(self, source: Union[Path, str], target = None):
+        """
+        Uploads a file to the given target location in the user workspace.
 
+        If the file exists in the user workspace it will be replaced.
 
-    def upload(self, source: Union[Path, str]):
+         :param source: A path to a file on the local file system to upload.
+        """
         # PUT /files/{path}
-        """ Uploaded (or replaces) a user-uploaded file."""
         path = Path(source)
         with path.open(mode="rb") as f:
             self.connection.put(self._get_endpoint(), expected_status=200, data=f)
@@ -58,5 +63,9 @@ class UserFile:
         self.connection.delete(self._get_endpoint(), expected_status=204)
 
     def to_dict(self) -> Dict[str, Any]:
-        """ Returns the provided metadata as dict."""
+        """
+        Returns the provided metadata as dict.
+
+        This is used in internal/jupyter.py to detect and get the original metadata.
+        """
         return self.metadata

--- a/openeo/rest/userfile.py
+++ b/openeo/rest/userfile.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Any, Dict, Union
+from typing import Any, Dict, Union, Optional
 from pathlib import Path, PurePosixPath
 from openeo.util import ensure_dir
 
@@ -13,13 +13,28 @@ class UserFile:
 
     def __init__(
         self,
-        path: Union[str, PurePosixPath],
+        path: Union[str, PurePosixPath, None],
+        *,
         connection: "Connection",
-        metadata: Dict[str, Any] = None,
+        metadata: Optional[dict] = None,
     ):
+        if path:
+            pass
+        elif metadata and metadata.get("path"):
+            path = metadata.get("path")
+        else:
+            raise ValueError(
+                "File path should be specified through `path` or `metadata` argument."
+            )
+
         self.path = PurePosixPath(path)
         self.metadata = metadata or {"path": path}
         self.connection = connection
+
+    @classmethod
+    def from_metadata(cls, metadata: dict, connection: "Connection") -> "UserFile":
+        """Build :py:class:`UserFile` from workspace file metadata dictionary."""
+        return cls(path=None, connection=connection, metadata=metadata)
 
     def __repr__(self):
         return '<{c} file={i!r}>'.format(c=self.__class__.__name__, i=self.path)
@@ -49,20 +64,16 @@ class UserFile:
 
         return target
 
-    def upload(self, source: Union[Path, str]):
+    def upload(self, source: Union[Path, str]) -> "UserFile":
         """
         Uploads a file to the given target location in the user workspace.
 
         If the file exists in the user workspace it will be replaced.
 
-         :param source: A path to a file on the local file system to upload.
+        :param source: A path to a file on the local file system to upload.
         """
         # PUT /files/{path}
-        # TODO: support other non-path sources too: bytes, open file, url, ...
-        path = Path(source)
-        with path.open(mode="rb") as f:
-            # TODO: `PUT /files/{path} results in new file metadata, so should we return a new UserFile here?
-            self.connection.put(self._get_endpoint(), expected_status=200, data=f)
+        return self.connection.upload_file(source, target=self.path)
 
     def delete(self):
         """ Delete a user-uploaded file."""

--- a/openeo/rest/userfile.py
+++ b/openeo/rest/userfile.py
@@ -70,8 +70,13 @@ class UserFile:
 
     def upload(self, source: Union[Path, str]) -> "UserFile":
         """
-        Uploads a local file to the given target location in the user workspace
+        Uploads a local file to the path corresponding to this :py:class:`UserFile` in the user workspace
         and returns new :py:class:`UserFile` of newly uploaded file.
+
+            .. tip::
+                Usually you'll just need
+                :py:meth:`Connection.upload_file() <openeo.rest.connection.Connection.upload_file>`
+                instead of this :py:class:`UserFile` method.
 
         If the file exists in the user workspace it will be replaced.
 

--- a/openeo/rest/userfile.py
+++ b/openeo/rest/userfile.py
@@ -9,7 +9,9 @@ if typing.TYPE_CHECKING:
 
 
 class UserFile:
-    """Represents a file in the user-workspace of openeo."""
+    """
+    Handle to a (user-uploaded) file in the user workspace on a openEO back-end.
+    """
 
     def __init__(
         self,
@@ -33,25 +35,27 @@ class UserFile:
 
     @classmethod
     def from_metadata(cls, metadata: dict, connection: "Connection") -> "UserFile":
-        """Build :py:class:`UserFile` from workspace file metadata dictionary."""
+        """Build :py:class:`UserFile` from a workspace file metadata dictionary."""
         return cls(path=None, connection=connection, metadata=metadata)
 
     def __repr__(self):
-        return '<{c} file={i!r}>'.format(c=self.__class__.__name__, i=self.path)
+        return "<{c} file={i!r}>".format(c=self.__class__.__name__, i=self.path)
 
     def _get_endpoint(self) -> str:
         return f"/files/{self.path!s}"
 
     def download(self, target: Union[Path, str] = None) -> Path:
         """
-        Downloads a user-uploaded file to the given location.
+        Downloads a user-uploaded file from the user workspace on the back-end
+        locally to the given location.
 
-         :param target: download target path. Can be an existing folder
+        :param target: local download target path. Can be an existing folder
              (in which case the file name advertised by backend will be used)
              or full file name. By default, the working directory will be used.
         """
-        # GET /files/{path}
-        response = self.connection.get(self._get_endpoint(), expected_status=200, stream=True)
+        response = self.connection.get(
+            self._get_endpoint(), expected_status=200, stream=True
+        )
 
         target = Path(target or Path.cwd())
         if target.is_dir():
@@ -66,24 +70,22 @@ class UserFile:
 
     def upload(self, source: Union[Path, str]) -> "UserFile":
         """
-        Uploads a file to the given target location in the user workspace.
+        Uploads a local file to the given target location in the user workspace
+        and returns new :py:class:`UserFile` of newly uploaded file.
 
         If the file exists in the user workspace it will be replaced.
 
         :param source: A path to a file on the local file system to upload.
+        :return: new :py:class:`UserFile` instance of the newly uploaded file
         """
-        # PUT /files/{path}
         return self.connection.upload_file(source, target=self.path)
 
     def delete(self):
-        """ Delete a user-uploaded file."""
-        # DELETE /files/{path}
+        """Delete the user-uploaded file from the user workspace on the back-end."""
         self.connection.delete(self._get_endpoint(), expected_status=204)
 
     def to_dict(self) -> Dict[str, Any]:
-        """
-        Returns the provided metadata as dict.
-
-        This is used in internal/jupyter.py to detect and get the original metadata.
-        """
+        """Returns the provided metadata as dict."""
+        # This is used in internal/jupyter.py to detect and get the original metadata.
+        # TODO: make this more explicit with an internal API?
         return self.metadata

--- a/openeo/rest/userfile.py
+++ b/openeo/rest/userfile.py
@@ -1,6 +1,8 @@
 import typing
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Union
+import os
 from pathlib import Path
+from openeo.util import ensure_dir
 
 if typing.TYPE_CHECKING:
     # Imports for type checking only (circular import issue at runtime).
@@ -10,9 +12,9 @@ if typing.TYPE_CHECKING:
 class UserFile:
     """Represents a file in the user-workspace of openeo."""
 
-    def __init__(self, path: str, connection: 'Connection', metadata: Dict[str, Any] = {}):
+    def __init__(self, path: str, connection: 'Connection', metadata: Dict[str, Any] = None):
         self.path = path
-        self.metadata = metadata
+        self.metadata = metadata or {"path": path}
         self.connection = connection
 
     def __repr__(self):
@@ -21,38 +23,41 @@ class UserFile:
     def _get_endpoint(self) -> str:
         return "/files/{}".format(self.path)
 
-    def get_metadata(self, key) -> Any:
-        """ Get metadata about the file, e.g. file size (key: 'size') or modification date (key: 'modified')."""
-        if key in self.metadata:
-            return self.metadata[key]
-        else:
-            return None
+    def download(self, target: Union[Path, str] = None) -> Path:
+        """
+        Downloads a user-uploaded file to the given location.
 
-    def download_file(self, target: Union[Path, str]) -> Path:
-        """ Downloads a user-uploaded file."""
+         :param target: download target path. Can be an existing folder 
+             (in which case the file name advertised by backend will be used) 
+             or full file name. By default, the working directory will be used.
+        """
         # GET /files/{path}
         response = self.connection.get(self._get_endpoint(), expected_status=200, stream=True)
 
-        path = Path(target)
-        with path.open(mode="wb") as f:
+        target = Path(target or Path.cwd()) 
+        if target.is_dir():
+            target = target / os.path.basename(self.path)
+        ensure_dir(target.parent)
+        
+        with target.open(mode="wb") as f:
             for chunk in response.iter_content(chunk_size=None):
                 f.write(chunk)
 
-        return path
+        return target
 
 
-    def upload_file(self, source: Union[Path, str]):
+    def upload(self, source: Union[Path, str]):
         # PUT /files/{path}
         """ Uploaded (or replaces) a user-uploaded file."""
         path = Path(source)
         with path.open(mode="rb") as f:
             self.connection.put(self._get_endpoint(), expected_status=200, data=f)
 
-    def delete_file(self):
+    def delete(self):
         """ Delete a user-uploaded file."""
         # DELETE /files/{path}
         self.connection.delete(self._get_endpoint(), expected_status=204)
 
     def to_dict(self) -> Dict[str, Any]:
         """ Returns the provided metadata as dict."""
-        return self.metadata if "path" in self.metadata else {"path": self.path}
+        return self.metadata

--- a/openeo/rest/userfile.py
+++ b/openeo/rest/userfile.py
@@ -1,6 +1,6 @@
 import typing
 from typing import Any, Dict, Union
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from openeo.util import ensure_dir
 
 if typing.TYPE_CHECKING:
@@ -12,7 +12,7 @@ class UserFile:
     """Represents a file in the user-workspace of openeo."""
 
     def __init__(self, path: str, connection: 'Connection', metadata: Dict[str, Any] = None):
-        self.path = Path(path)
+        self.path = PurePosixPath(path)
         self.metadata = metadata or {"path": path}
         self.connection = connection
 
@@ -26,25 +26,25 @@ class UserFile:
         """
         Downloads a user-uploaded file to the given location.
 
-         :param target: download target path. Can be an existing folder 
-             (in which case the file name advertised by backend will be used) 
+         :param target: download target path. Can be an existing folder
+             (in which case the file name advertised by backend will be used)
              or full file name. By default, the working directory will be used.
         """
         # GET /files/{path}
         response = self.connection.get(self._get_endpoint(), expected_status=200, stream=True)
 
-        target = Path(target or Path.cwd()) 
+        target = Path(target or Path.cwd())
         if target.is_dir():
             target = target / self.path.name
         ensure_dir(target.parent)
-        
+
         with target.open(mode="wb") as f:
             for chunk in response.iter_content(chunk_size=None):
                 f.write(chunk)
 
         return target
-    
-    def upload(self, source: Union[Path, str], target = None):
+
+    def upload(self, source: Union[Path, str]):
         """
         Uploads a file to the given target location in the user workspace.
 

--- a/openeo/rest/userfile.py
+++ b/openeo/rest/userfile.py
@@ -11,7 +11,12 @@ if typing.TYPE_CHECKING:
 class UserFile:
     """Represents a file in the user-workspace of openeo."""
 
-    def __init__(self, path: str, connection: 'Connection', metadata: Dict[str, Any] = None):
+    def __init__(
+        self,
+        path: Union[str, PurePosixPath],
+        connection: "Connection",
+        metadata: Dict[str, Any] = None,
+    ):
         self.path = PurePosixPath(path)
         self.metadata = metadata or {"path": path}
         self.connection = connection
@@ -53,8 +58,10 @@ class UserFile:
          :param source: A path to a file on the local file system to upload.
         """
         # PUT /files/{path}
+        # TODO: support other non-path sources too: bytes, open file, url, ...
         path = Path(source)
         with path.open(mode="rb") as f:
+            # TODO: `PUT /files/{path} results in new file metadata, so should we return a new UserFile here?
             self.connection.put(self._get_endpoint(), expected_status=200, data=f)
 
     def delete(self):

--- a/tests/rest/test_userfile.py
+++ b/tests/rest/test_userfile.py
@@ -1,0 +1,168 @@
+from openeo.rest import OpenEoApiError
+from openeo.rest.userfile import UserFile
+from pathlib import Path, PurePosixPath
+import pytest
+import openeo
+from openeo.util import rfc3339
+
+API_URL = "https://oeo.test"
+
+
+@pytest.fixture
+def con100(requests_mock) -> openeo.Connection:
+    requests_mock.get(API_URL + "/", json={"api_version": "1.0.0"})
+    con = openeo.connect(API_URL)
+    return con
+
+
+class TestUserFile:
+    def test_simple(self, con100):
+        f = UserFile("foo.txt", connection=con100)
+        assert f.path == PurePosixPath("foo.txt")
+
+    def test_connection_get_file(self, con100):
+        f = con100.get_file("foo.txt")
+        assert f.path == PurePosixPath("foo.txt")
+
+    def test_connection_list_files(self, con100, requests_mock):
+        requests_mock.get(
+            API_URL + "/files",
+            json={
+                "files": [
+                    {
+                        "path": "foo.txt",
+                        "size": 182,
+                        "modified": "2015-10-20T17:22:10Z",
+                    },
+                    {
+                        "path": "data/foo.tiff",
+                        "size": 183142,
+                        "modified": "2017-01-01T09:36:18Z",
+                    },
+                ],
+            },
+        )
+        files = con100.list_files()
+        assert len(files)
+        assert files[0].path == PurePosixPath("foo.txt")
+        assert files[0].metadata == {
+            "path": "foo.txt",
+            "size": 182,
+            "modified": "2015-10-20T17:22:10Z",
+        }
+        assert files[1].path == PurePosixPath("data/foo.tiff")
+        assert files[1].metadata == {
+            "path": "data/foo.tiff",
+            "size": 183142,
+            "modified": "2017-01-01T09:36:18Z",
+        }
+
+    def test_upload(self, con100, tmp_path, requests_mock):
+        source = tmp_path / "to-upload.txt"
+        source.write_text("hello world\n")
+        f = UserFile("foo.txt", connection=con100)
+
+        def put_files(request, context):
+            import io
+
+            if isinstance(request.text, io.BufferedReader):
+                body = request.text.read()
+            else:
+                body = request.text
+            assert body == b"hello world\n"
+            context.status_code = 200
+            return {
+                "path": "foo.txt",
+                "size": len(body),
+                "modified": "2018-01-03T10:55:29Z",
+            }
+
+        upload_mock = requests_mock.put(API_URL + "/files/foo.txt", json=put_files)
+
+        # TODO: check response?
+        f.upload(source)
+
+        assert upload_mock.call_count == 1
+
+    @pytest.mark.parametrize("status_code", [404, 500])
+    def test_upload_fail(self, tmp_path, con100, requests_mock, status_code):
+        source = tmp_path / "to-upload.txt"
+        source.write_text("hello world\n")
+        f = UserFile("foo.txt", connection=con100)
+
+        upload_mock = requests_mock.put(
+            API_URL + "/files/foo.txt", status_code=status_code
+        )
+
+        with pytest.raises(OpenEoApiError, match=rf"\[{status_code}\]"):
+            f.upload(source)
+
+        assert upload_mock.call_count == 1
+
+    @pytest.mark.parametrize(
+        ["target", "expected_target"],
+        [
+            (None, "to-upload.txt"),
+            ("foo.txt", "foo.txt"),
+        ],
+    )
+    def test_connection_upload(
+        self, con100, tmp_path, requests_mock, target, expected_target
+    ):
+        source = tmp_path / "to-upload.txt"
+        source.write_text("hello world\n")
+
+        def put_files(request, context):
+            import io
+
+            if isinstance(request.text, io.BufferedReader):
+                body = request.text.read()
+            else:
+                body = request.text
+            assert body == b"hello world\n"
+            context.status_code = 200
+            return {
+                "path": request.path,
+                "size": len(body),
+                "modified": "2018-01-03T10:55:29Z",
+            }
+
+        upload_mock = requests_mock.put(
+            API_URL + f"/files/{expected_target}", json=put_files
+        )
+
+        f = con100.upload_file(source, target=target)
+        assert upload_mock.call_count == 1
+
+        # TODO
+        # assert f.path == PurePosixPath(expected_target)
+        # assert f.metadata == {}
+
+    @pytest.mark.parametrize(
+        ["target", "expected"],
+        [
+            (None, "foo.txt"),
+            ("data", "data/foo.txt"),
+            ("data/bar.txt", "data/bar.txt"),
+        ],
+    )
+    def test_download(
+        self, con100, tmp_path, requests_mock, target, expected, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+
+        download_mock = requests_mock.get(
+            API_URL + "/files/foo.txt", content=b"hello world\n"
+        )
+
+        if target is not None:
+            target = tmp_path / target
+
+        f = UserFile("foo.txt", connection=con100)
+        f.download(target)
+
+        expected = tmp_path / expected
+        assert expected.exists()
+        assert expected.read_bytes() == b"hello world\n"
+        assert download_mock.call_count == 1


### PR DESCRIPTION
Implements #377

It seems the Python client only allowed to list files so far, which was not very useful. Added full support for the /files endpoints.

What do you think, @soxofaan ?
It's available in all clients except for Python so I think it should be added to push towards full openEO API support.

Interface looks like this (filenames/paths don't make any sense...):
![image](https://user-images.githubusercontent.com/8262166/219695525-531708c8-4b09-4f6c-887f-27fc20fbd419.png)

Has been tested successfully against the GEE back-end.