### PR TITLE
Issue #387 openeo.connect, reinstate old behavior: no PermissionError on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reinstated old behavior of authenticate_oidc on Windows: when PrivateJsonFile may be readable by others, log message instead of raising PermissionError ([387](https://github.com/Open-EO/openeo-python-client/issues/387))
+- Reinstated old behavior of authentication related user files (e.g. refresh token store) on Windows: when `PrivateJsonFile` may be readable by others, just log a message instead of raising `PermissionError` ([387](https://github.com/Open-EO/openeo-python-client/issues/387))
 
 
 ## [0.15.0] - 2023-03-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reinstated old behavior of authenticate_oidc on Windows: when PrivateJsonFile may be readable by others, log message instead of raising PermissionError ([387](https://github.com/Open-EO/openeo-python-client/issues/387))
+
 
 ## [0.15.0] - 2023-03-03
 

--- a/openeo/rest/auth/config.py
+++ b/openeo/rest/auth/config.py
@@ -9,6 +9,7 @@ from local config files.
 import json
 import logging
 import stat
+import platform
 from datetime import datetime
 from pathlib import Path
 from typing import Union, Tuple, Dict
@@ -52,7 +53,10 @@ def assert_private_file(path: Path):
         message = "File {p} could be readable by others: mode {a:o} (expected: {e:o}).".format(
             p=path, a=mode & (stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO), e=_PRIVATE_PERMS
         )
-        raise PermissionError(message)
+        if platform.system() == "Windows":
+            log.info(message)
+        else:
+            raise PermissionError(message)
 
 
 def utcnow_rfc3339() -> str:

--- a/tests/rest/auth/test_config.py
+++ b/tests/rest/auth/test_config.py
@@ -1,4 +1,7 @@
+import logging
 import json
+import platform
+import re
 from unittest import mock
 
 import pytest
@@ -34,15 +37,35 @@ class TestPrivateJsonFile:
         st_mode = get_file_mode(private.path)
         assert st_mode & 0o777 == 0o600
 
-    def test_wrong_permissions(self, tmp_path):
+    def test_wrong_permissions(self, tmp_path, caplog):
         private = PrivateJsonFile(tmp_path)
         with private.path.open("w") as f:
             json.dump({"foo": "bar"}, f)
         assert private.path.stat().st_mode & 0o077 > 0
-        with pytest.raises(PermissionError, match="readable by others.*expected: 600"):
+
+        if platform.system() != "Windows":
+            with pytest.raises(
+                PermissionError, match="readable by others.*expected: 600"
+            ):
+                private.get("foo")
+            with pytest.raises(
+                PermissionError, match="readable by others.*expected: 600"
+            ):
+                private.set("foo", value="lol")
+        else:
+            regex = re.compile("readable by others.*expected: 600")
+            caplog.set_level(logging.INFO)
+
             private.get("foo")
-        with pytest.raises(PermissionError, match="readable by others.*expected: 600"):
+            assert caplog.record_tuples[0][1] == logging.INFO
+            message = caplog.record_tuples[0][2]
+            assert regex.search(message)
+
+            caplog.clear()
             private.set("foo", value="lol")
+            assert caplog.record_tuples[0][1] == logging.INFO
+            message = caplog.record_tuples[0][2]
+            assert regex.search(message)
 
     def test_set_get(self, tmp_path):
         private = PrivateJsonFile(tmp_path)
@@ -138,15 +161,34 @@ class TestAuthConfig:
 
 class TestRefreshTokenStorage:
 
-    def test_public_file(self, tmp_path):
+    def test_public_file(self, tmp_path, caplog):
         path = tmp_path / "refresh_tokens.json"
         with path.open("w") as f:
             json.dump({}, f)
         r = RefreshTokenStore(path=path)
-        with pytest.raises(PermissionError, match="readable by others.*expected: 600"):
+        if platform.system() != "Windows":
+            with pytest.raises(
+                PermissionError, match="readable by others.*expected: 600"
+            ):
+                r.get_refresh_token("foo", "bar")
+            with pytest.raises(
+                PermissionError, match="readable by others.*expected: 600"
+            ):
+                r.set_refresh_token("foo", "bar", "imd6$3cr3t")
+        else:
+            regex = re.compile("readable by others.*expected: 600")
+            caplog.set_level(logging.INFO)
+
             r.get_refresh_token("foo", "bar")
-        with pytest.raises(PermissionError, match="readable by others.*expected: 600"):
+            assert caplog.record_tuples[0][1] == logging.INFO
+            message = caplog.record_tuples[0][2]
+            assert regex.search(message)
+
+            caplog.clear()
             r.set_refresh_token("foo", "bar", "imd6$3cr3t")
+            assert caplog.record_tuples[0][1] == logging.INFO
+            message = caplog.record_tuples[0][2]
+            assert regex.search(message)
 
     def test_permissions(self, tmp_path):
         r = RefreshTokenStore(path=tmp_path)


### PR DESCRIPTION
## Issue #387 Quick fix, reinstate old behavior: no PermissionError on Windows for PrivateJsonFile, log message instead

Fixes https://github.com/Open-EO/openeo-python-client/issues/387

Reinstated the old behavior of authenticate_oidc on Windows: 
When PrivateJsonFile may be readable by others, log message instead of raising a PermissionError.


There is a follow-up issue here #400, if we still want to find a more secure solution for Windows.
To be decided.


Also, for now I have left in the code that uses oschmod because:

1) when it does work, then it still adds a bit more security;
2) we would like to get a solution out quickly, but removing oschmod cleanly takes a bit more work and care.
