### PR TITLE
[localprocessing] updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ docs_require = [
 localprocessing_require = [
     "rioxarray",
     "pyproj",
-    "openeo_pg_parser_networkx>=2023.1.2",
-    "openeo_processes_dask>=2023.3.0",
+    "openeo_pg_parser_networkx==2023.3.1",
+    "openeo_processes_dask[implementations]==2023.3.2",
 ]
 
 


### PR DESCRIPTION
New PR to update the `localprocessing` functionalities:

- Fixes dependencies
- Code now parsing correctly band names for geoTIFFs if are present and set them in the metadata.

@soxofaan the `openeo-python-client` requires Python 3.6+. However, some of the functionalities I implemented require Python 3.9+. Is it possible to specify this somewhere?

I will also add the documentation to this PR later.