### PR TITLE
Pass log_level to backend when getting BatchJob logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   moved accordingly to the `VectorCube` class.
 - Improved documentation on `openeo.processes` and `ProcessBuilder`
   ([#390](https://github.com/Open-EO/openeo-python-client/issues/390)).
+- Pass log_level to backend when retrieving BatchJob's logs. ([Open-EO/openeo-python-driver#170](https://github.com/Open-EO/openeo-python-driver/issues/170))
 
 ### Removed
 

--- a/openeo/api/logs.py
+++ b/openeo/api/logs.py
@@ -89,3 +89,10 @@ def normalize_log_level(
         raise TypeError(
             f"Value for log_level is not an int or str: type={type(log_level)}, value={log_level!r}"
         )
+
+
+def log_level_name(log_level):
+    """Get the name of a normalized log level.
+    This value conforms to log level names used in the openeo API.
+    """
+    return logging.getLevelName(normalize_log_level(log_level)).lower()

--- a/openeo/extra/job_management.py
+++ b/openeo/extra/job_management.py
@@ -376,8 +376,7 @@ class MultiBackendJobManager:
         """
         # TODO: param `row` is never accessed in this method. Remove it? Is this intended for future use?
 
-        logs = job.logs()
-        error_logs = [l for l in logs if l.level.lower() == "error"]
+        error_logs = job.logs(log_level="error")
         error_log_path = self.get_error_log_path(job.job_id)
 
         if len(error_logs) > 0:

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -237,7 +237,7 @@ class Connection(RestApiConnection):
         self._capabilities_cache = LazyLoadCache()
 
         # Initial API version check.
-        self.api_version.require_at_least(self._MINIMUM_API_VERSION)
+        self._api_version.require_at_least(self._MINIMUM_API_VERSION)
 
         self._auth_config = auth_config
         self._refresh_token_store = refresh_token_store
@@ -897,7 +897,7 @@ class Connection(RestApiConnection):
         return self.post(path="/validation", json=request, expected_status=200).json()["errors"]
 
     @property
-    def api_version(self) -> ComparableVersion:
+    def _api_version(self) -> ComparableVersion:
         # TODO make this a public property (it's also useful outside the Connection class)
         return self.capabilities().api_version_check
 

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -237,7 +237,7 @@ class Connection(RestApiConnection):
         self._capabilities_cache = LazyLoadCache()
 
         # Initial API version check.
-        self._api_version.require_at_least(self._MINIMUM_API_VERSION)
+        self.api_version.require_at_least(self._MINIMUM_API_VERSION)
 
         self._auth_config = auth_config
         self._refresh_token_store = refresh_token_store
@@ -897,7 +897,7 @@ class Connection(RestApiConnection):
         return self.post(path="/validation", json=request, expected_status=200).json()["errors"]
 
     @property
-    def _api_version(self) -> ComparableVersion:
+    def api_version(self) -> ComparableVersion:
         # TODO make this a public property (it's also useful outside the Connection class)
         return self.capabilities().api_version_check
 

--- a/openeo/rest/job.py
+++ b/openeo/rest/job.py
@@ -177,21 +177,16 @@ class BatchJob:
             url, params={"offset": offset, "log_level": log_level}, expected_status=200
         ).json()["logs"]
 
-        #
-        # TODO: we should still support client-side log_level filtering when the backend
-        #   itself doesn't support filtering. What is the best way to check that, the API version?
-        #   https://github.com/Open-EO/openeo-python-driver/issues/170
-        #
-
         # Only filter logs when specified.
-        if self.connection.api_version.at_most("1.1.0"):
-            if log_level is not None:
-                log_level = normalize_log_level(log_level)
-                logs = (
-                    log
-                    for log in logs
-                    if normalize_log_level(log.get("level")) >= log_level
-                )
+        # We should still support client-side log_level filtering because not all backends
+        # support the log_level option.
+        if log_level is not None:
+            log_level = normalize_log_level(log_level)
+            logs = (
+                log
+                for log in logs
+                if normalize_log_level(log.get("level")) >= log_level
+            )
 
         entries = [LogEntry(log) for log in logs]
         return VisualList("logs", data=entries)

--- a/openeo/rest/job.py
+++ b/openeo/rest/job.py
@@ -173,16 +173,25 @@ class BatchJob:
         :return: A list containing the log entries for the batch job.
         """
         url = f"/jobs/{self.job_id}/logs"
-        logs = self.connection.get(url, params={'offset': offset}, expected_status=200).json()["logs"]
+        logs = self.connection.get(
+            url, params={"offset": offset, "log_level": log_level}, expected_status=200
+        ).json()["logs"]
+
+        #
+        # TODO: we should still support client-side log_level filtering when the backend
+        #   itself doesn't support filtering. What is the best way to check that, the API version?
+        #   https://github.com/Open-EO/openeo-python-driver/issues/170
+        #
 
         # Only filter logs when specified.
-        if log_level is not None:
-            log_level = normalize_log_level(log_level)
-            logs = (
-                log
-                for log in logs
-                if normalize_log_level(log.get("level")) >= log_level
-            )
+        if self.connection.api_version.at_most("1.1.0"):
+            if log_level is not None:
+                log_level = normalize_log_level(log_level)
+                logs = (
+                    log
+                    for log in logs
+                    if normalize_log_level(log.get("level")) >= log_level
+                )
 
         entries = [LogEntry(log) for log in logs]
         return VisualList("logs", data=entries)

--- a/openeo/rest/job.py
+++ b/openeo/rest/job.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import logging
-import textwrap
 import time
 import typing
 from pathlib import Path
@@ -9,7 +8,7 @@ from typing import List, Union, Dict, Optional
 
 import requests
 
-from openeo.api.logs import LogEntry, normalize_log_level
+from openeo.api.logs import LogEntry, normalize_log_level, log_level_name
 from openeo.internal.jupyter import render_component, render_error, VisualDict, VisualList
 from openeo.internal.warnings import deprecated
 from openeo.rest import OpenEoClientException, JobFailedException, OpenEoApiError
@@ -174,7 +173,9 @@ class BatchJob:
         """
         url = f"/jobs/{self.job_id}/logs"
         logs = self.connection.get(
-            url, params={"offset": offset, "log_level": log_level}, expected_status=200
+            url,
+            params={"offset": offset, "log_level": log_level_name(log_level)},
+            expected_status=200,
         ).json()["logs"]
 
         # Only filter logs when specified.


### PR DESCRIPTION
Part of implementation for Open-EO/openeo-python-driver#170

This fix has to be done across three code bases with their respective PRs

The main PR is: https://github.com/Open-EO/openeo-python-driver/pull/174

The code bases are:

- https://github.com/Open-EO/openeo-geopyspark-driver : Where logs are actually retrieved from Elasticsearch
- https://github.com/Open-EO/openeo-python-driver : needs to link through log_level parameter to backend implementation
- https://github.com/Open-EO/openeo-python-client : needs to be use log_level when retrieving logs via the openeo-python-driver