### PR TITLE
[localprocessing] Fixed required packages versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ docs_require = [
 localprocessing_require = [
     "rioxarray",
     "pyproj",
-    "openeo_pg_parser_networkx>=2023.1.2",
-    "openeo_processes_dask>=2023.3.0",
+    "openeo_pg_parser_networkx==2023.3.1",
+    "openeo_processes_dask[implementations]==2023.3.2",
 ]
 
 


### PR DESCRIPTION
Fixed required versions of openeo_pg_parser_networkx and openeo_processes_dask to the latest tested versions, to avoid incompatibilities and functionalities breaks due to updates.