### PR TITLE
Job manager: trigger on_job_done for finished job from all active states

### DIFF
--- a/openeo/extra/job_management.py
+++ b/openeo/extra/job_management.py
@@ -419,10 +419,7 @@ class MultiBackendJobManager:
                 _log.info(
                     f"Status of job {job_id!r} (on backend {backend_name}) is {job_metadata['status']!r}"
                 )
-                if (
-                    df.loc[i, "status"] == "running"
-                    and job_metadata["status"] == "finished"
-                ):
+                if job_metadata["status"] == "finished":
                     self.on_job_done(the_job, df.loc[i])
                 if df.loc[i, "status"] != "error" and job_metadata["status"] == "error":
                     self.on_job_error(the_job, df.loc[i])


### PR DESCRIPTION
Right now, the `on_job_done()` method will only be triggered when the cached state is `running` and the job status is `finished`. But it might be possible that the job manager was stopped and resumed later and jobs in another _active_ state (`created`, `queued`) finished in the mean time.
For example, this means that jobs going from `queued` to `finished` will not trigger the `on_job_done()` method.

This PR changes the behaviour of the job manager to trigger the `on_job_done()` method on the transition from **any** active state to the `finished` state.