### PR TITLE
define a new udf signature to separate metadata from data transformation

### DIFF
--- a/docs/udf.rst
+++ b/docs/udf.rst
@@ -277,6 +277,19 @@ instead of the original digital number range (thousands):
 .. image:: _static/images/udf/apply-rescaled-histogram.png
 
 
+UDF's that transform cube metadata
+==================================
+In some cases, a UDF can have impact on the metadata of a cube, but this can not always
+be easily inferred by process graph evaluation logic without running the actual
+(expensive) UDF code. This limits the possibilities to validate process graphs,
+or for instance make an estimate of the size of a datacube after applying a UDF.
+
+To provide evaluation logic with this information, the user should implement the
+:py:meth:`~openeo.udf.udf_signatures.apply_metadata()` function as part of the UDF.
+Please refer to the documentation of that function for more information.
+
+
+
 Illustration of data chunking in ``apply`` with a  UDF
 ========================================================
 

--- a/openeo/udf/udf_signatures.py
+++ b/openeo/udf/udf_signatures.py
@@ -10,6 +10,7 @@ from pandas import Series
 
 from openeo.udf.udf_data import UdfData
 from openeo.udf.xarraydatacube import XarrayDataCube
+from openeo.metadata import CollectionMetadata
 
 
 def apply_timeseries(series: Series, context: dict) -> Series:
@@ -48,5 +49,36 @@ def apply_udf_data(data: UdfData):
     Generic UDF function that directly manipulates a :py:class:`UdfData` object
 
     :param data: :py:class:`UdfData` object to manipulate in-place
+    """
+    pass
+
+
+def apply_metadata(input_metadata:CollectionMetadata, context:dict) -> CollectionMetadata:
+    """
+    .. warning::
+        This signature is not yet fully standardized and subject to change.
+
+    Returns the expected cube metadata, after applying this UDF, based on input metadata.
+    The provided metadata represents the whole raster or vector cube. This function does not need to be called for every data chunk.
+
+    When this function is not implemented by the UDF, the backend may still be able to infer correct metadata by running the
+    UDF, but this can result in reduced performance or errors.
+
+    This function does not need to be provided when using the UDF in combination with processes that by design have a clear
+    effect on cube metadata, such as :py:meth:`~openeo.rest.datacube.DataCube.reduce_dimension()`
+
+    :param input_metadata: the collection metadata of the input data cube
+    :param context: A dictionary containing user context.
+
+    :return: output metadata: the expected metadata of the cube, after applying the udf
+
+    Examples
+    --------
+
+    An example for a UDF that is applied on the 'bands' dimension, and returns a new set of bands with different labels.
+    >>> def convert_dimensions(input_metadata:CollectionMetadata, context:dict) -> CollectionMetadata:
+    >>>     return input_metadata.rename_labels("bands",target=["computed_band_1","computed_band_2"])
+    >>>
+
     """
     pass

--- a/openeo/udf/udf_signatures.py
+++ b/openeo/udf/udf_signatures.py
@@ -53,7 +53,7 @@ def apply_udf_data(data: UdfData):
     pass
 
 
-def apply_metadata(input_metadata:CollectionMetadata, context:dict) -> CollectionMetadata:
+def apply_metadata(metadata:CollectionMetadata, context:dict) -> CollectionMetadata:
     """
     .. warning::
         This signature is not yet fully standardized and subject to change.
@@ -67,7 +67,7 @@ def apply_metadata(input_metadata:CollectionMetadata, context:dict) -> Collectio
     This function does not need to be provided when using the UDF in combination with processes that by design have a clear
     effect on cube metadata, such as :py:meth:`~openeo.rest.datacube.DataCube.reduce_dimension()`
 
-    :param input_metadata: the collection metadata of the input data cube
+    :param metadata: the collection metadata of the input data cube
     :param context: A dictionary containing user context.
 
     :return: output metadata: the expected metadata of the cube, after applying the udf
@@ -76,8 +76,8 @@ def apply_metadata(input_metadata:CollectionMetadata, context:dict) -> Collectio
     --------
 
     An example for a UDF that is applied on the 'bands' dimension, and returns a new set of bands with different labels.
-    >>> def apply_metadata(input_metadata:CollectionMetadata, context:dict) -> CollectionMetadata:
-    >>>     return input_metadata.rename_labels("bands",target=["computed_band_1","computed_band_2"])
+    >>> def apply_metadata(metadata:CollectionMetadata, context:dict) -> CollectionMetadata:
+    >>>     return metadata.rename_labels("bands",target=["computed_band_1","computed_band_2"])
     >>>
 
     """

--- a/openeo/udf/udf_signatures.py
+++ b/openeo/udf/udf_signatures.py
@@ -76,7 +76,7 @@ def apply_metadata(input_metadata:CollectionMetadata, context:dict) -> Collectio
     --------
 
     An example for a UDF that is applied on the 'bands' dimension, and returns a new set of bands with different labels.
-    >>> def convert_dimensions(input_metadata:CollectionMetadata, context:dict) -> CollectionMetadata:
+    >>> def apply_metadata(input_metadata:CollectionMetadata, context:dict) -> CollectionMetadata:
     >>>     return input_metadata.rename_labels("bands",target=["computed_band_1","computed_band_2"])
     >>>
 


### PR DESCRIPTION
Separating metadata transformation allows process graph analysis to work better when UDF's perform more complex transformations.
One example was requested in this issue:
https://github.com/Open-EO/openeo-geopyspark-driver/issues/412

Applies for instance to UDF's that:
- change band labels
- change spatial resolution
- change crs of spatial dimension
- change timestamps on temporal dimension

I requested some reviews as this is an extension of the UDF API. It's a non-breaking change, UDF's that work will continue to work.
@m-mohr  I'll want to make this an agenda topic on one of the next dev meetings. Do we require PSC approval for changes to UDF API?