### PR TITLE
Urgent: add validate to local .execute()

### DIFF
--- a/openeo/local/connection.py
+++ b/openeo/local/connection.py
@@ -253,7 +253,7 @@ class LocalConnection():
         cube.metadata = metadata
         return cube
 
-    def execute(self, process_graph: Union[dict, str, Path]) -> xr.DataArray:
+    def execute(self, process_graph: Union[dict, str, Path], validate: Optional[bool] = None) -> xr.DataArray:
         """
         Execute locally the process graph and return the result as an xarray.DataArray.
 


### PR DESCRIPTION
@soxofaan @jdries
The introduction of the validate parameter here: https://github.com/Open-EO/openeo-python-client/blob/0fbe895da2a0cd5e499c773df5ffd8aef9a63b2b/openeo/rest/datacube.py#L2211 breaks all the local processing calls.

This PR fixes this, urgent to merge and release.