### PR TITLE
catch json decode errors in connection.execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- `Connection.execute()` and `DataCube.execute()` now have a `auto_decode` argument. If set to True (default) the response will be decoded as a JSON and throw an exception if this fails, if set to False the raw `requests.Response` object will be returned. ([#499](https://github.com/Open-EO/openeo-python-client/issues/499))
 
 ### Removed
 

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -1600,11 +1600,10 @@ class Connection(RestApiConnection):
         if auto_decode:
             try:
                 return response.json()
-            except requests.exceptions.JSONDecodeError:
-                _log.warning(
+            except requests.exceptions.JSONDecodeError as e:
+                raise OpenEoClientException(
                     "Failed to decode response as JSON. For other data types use `download` method instead of `execute`."
-                )
-                raise
+                ) from e
         else:
             return response
 

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -1601,8 +1601,10 @@ class Connection(RestApiConnection):
             try:
                 return response.json()
             except requests.exceptions.JSONDecodeError:
-                _log.warning("Failed to decode response as JSON, returning raw response.")
-                return response
+                _log.warning(
+                    "Failed to decode response as JSON. For other data types use `download` method instead of `execute`."
+                )
+                raise
         else:
             return response
 

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -1577,7 +1577,7 @@ class Connection(RestApiConnection):
         timeout: Optional[int] = None,
         validate: Optional[bool] = None,
         auto_decode: bool = True,
-    ):
+    ) -> Union[dict, requests.Response]:
         """
         Execute a process graph synchronously and return the result. If the result is a JSON object, it will be parsed.
 
@@ -1587,7 +1587,7 @@ class Connection(RestApiConnection):
             (overruling the connection's ``auto_validate`` setting).
         :param auto_decode: Boolean flag to enable/disable automatic JSON decoding of the response. Defaults to True.
 
-        :return: if possible parsed JSON response, otherwise raw response
+        :return: parsed JSON response as a dict if auto_decode is True, otherwise response object
         """
         pg_with_metadata = self._build_request_with_process_graph(process_graph=process_graph)
         self._preflight_validation(pg_with_metadata=pg_with_metadata, validate=validate)

--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -18,6 +18,7 @@ from builtins import staticmethod
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union, Callable
 
 import numpy as np
+import requests
 import shapely.geometry
 import shapely.geometry.base
 from shapely.geometry import MultiPolygon, Polygon, mapping
@@ -2306,7 +2307,7 @@ class DataCube(_ProcessGraphAbstraction):
             returns=returns, categories=categories, examples=examples, links=links,
         )
 
-    def execute(self, *, validate: Optional[bool] = None, auto_decode: bool = True) -> dict:
+    def execute(self, *, validate: Optional[bool] = None, auto_decode: bool = True) -> Union[dict, requests.Response]:
         """
         Execute a process graph synchronously and return the result. If the result is a JSON object, it will be parsed.
 
@@ -2314,7 +2315,7 @@ class DataCube(_ProcessGraphAbstraction):
             (overruling the connection's ``auto_validate`` setting).
         :param auto_decode: Boolean flag to enable/disable automatic JSON decoding of the response. Defaults to True.
 
-        :return: if possible parsed JSON response, otherwise raw response
+        :return: parsed JSON response as a dict if auto_decode is True, otherwise response object
         """
         return self._connection.execute(self.flat_graph(), validate=validate, auto_decode=auto_decode)
 

--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -2306,9 +2306,9 @@ class DataCube(_ProcessGraphAbstraction):
             returns=returns, categories=categories, examples=examples, links=links,
         )
 
-    def execute(self, *, validate: Optional[bool] = None) -> dict:
+    def execute(self, *, validate: Optional[bool] = None, auto_decode: bool = True) -> dict:
         """Executes the process graph."""
-        return self._connection.execute(self.flat_graph(), validate=validate)
+        return self._connection.execute(self.flat_graph(), validate=validate, auto_decode=auto_decode)
 
     @staticmethod
     @deprecated(reason="Use :py:func:`openeo.udf.run_code.execute_local_udf` instead", version="0.7.0")

--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -2307,7 +2307,15 @@ class DataCube(_ProcessGraphAbstraction):
         )
 
     def execute(self, *, validate: Optional[bool] = None, auto_decode: bool = True) -> dict:
-        """Executes the process graph."""
+        """
+        Execute a process graph synchronously and return the result. If the result is a JSON object, it will be parsed.
+
+        :param validate: Optional toggle to enable/prevent validation of the process graphs before execution
+            (overruling the connection's ``auto_validate`` setting).
+        :param auto_decode: Boolean flag to enable/disable automatic JSON decoding of the response. Defaults to True.
+
+        :return: if possible parsed JSON response, otherwise raw response
+        """
         return self._connection.execute(self.flat_graph(), validate=validate, auto_decode=auto_decode)
 
     @staticmethod

--- a/tests/rest/datacube/test_datacube.py
+++ b/tests/rest/datacube/test_datacube.py
@@ -10,11 +10,10 @@ from unittest import mock
 
 import numpy as np
 import pytest
-from requests import JSONDecodeError
 import shapely
 import shapely.geometry
 
-from openeo.rest import BandMathException
+from openeo.rest import BandMathException, OpenEoClientException
 from openeo.rest._testing import build_capabilities
 from openeo.rest.connection import Connection
 from openeo.rest.datacube import DataCube
@@ -557,14 +556,16 @@ def test_execute_json_decode(connection, requests_mock):
 def test_execute_decode_error(connection, requests_mock):
     requests_mock.get(API_URL + "/collections/S2", json={})
     requests_mock.post(API_URL + "/result", content=b"tiffdata")
-    with pytest.raises(JSONDecodeError):
+    with pytest.raises(OpenEoClientException):
         connection.load_collection("S2").execute(auto_decode=True)
+        # TODO check if the message is correct (bevat deze woorden)
 
 
 def test_execute_json_raw(connection, requests_mock):
     requests_mock.get(API_URL + "/collections/S2", json={})
     requests_mock.post(API_URL + "/result", content=b'{"foo": "bar"}')
     result = connection.load_collection("S2").execute(auto_decode=False)
+    # TODO assert isinstance requests.Response
     assert result.content == b'{"foo": "bar"}'
 
 

--- a/tests/rest/datacube/test_datacube.py
+++ b/tests/rest/datacube/test_datacube.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import numpy as np
 import pytest
+import requests
 import shapely
 import shapely.geometry
 
@@ -564,7 +565,7 @@ def test_execute_json_raw(connection, requests_mock):
     requests_mock.get(API_URL + "/collections/S2", json={})
     requests_mock.post(API_URL + "/result", content=b'{"foo": "bar"}')
     result = connection.load_collection("S2").execute(auto_decode=False)
-    # TODO assert isinstance requests.Response
+    assert isinstance(result, requests.Response)
     assert result.content == b'{"foo": "bar"}'
 
 

--- a/tests/rest/datacube/test_datacube.py
+++ b/tests/rest/datacube/test_datacube.py
@@ -556,9 +556,8 @@ def test_execute_json_decode(connection, requests_mock):
 def test_execute_decode_error(connection, requests_mock):
     requests_mock.get(API_URL + "/collections/S2", json={})
     requests_mock.post(API_URL + "/result", content=b"tiffdata")
-    with pytest.raises(OpenEoClientException):
+    with pytest.raises(OpenEoClientException, match="Failed to decode response as JSON.*$"):
         connection.load_collection("S2").execute(auto_decode=True)
-        # TODO check if the message is correct (bevat deze woorden)
 
 
 def test_execute_json_raw(connection, requests_mock):

--- a/tests/rest/datacube/test_datacube.py
+++ b/tests/rest/datacube/test_datacube.py
@@ -573,6 +573,7 @@ def test_execute_tiff_raw(connection, requests_mock):
     requests_mock.get(API_URL + "/collections/S2", json={})
     requests_mock.post(API_URL + "/result", content=b"tiffdata")
     result = connection.load_collection("S2").execute(auto_decode=False)
+    assert isinstance(result, requests.Response)
     assert result.content == b"tiffdata"
 
 @pytest.mark.parametrize(["filename", "expected_format"], [


### PR DESCRIPTION
github issue #499
added try/except to connection.execute to catch json decode errors
If a json decode error occurs, the response is return raw. 
(Follows [eafp](https://docs.python.org/2/glossary.html#term-eafp))