### PR TITLE
changed default download chunk size to 10MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- Changed default `chunk_size` of various `download` functions from None to 10MB. This improves the handling of large downloads and reduces memory usage.
+- Changed default `chunk_size` of various `download` functions from None to 10MB. This improves the handling of large downloads and reduces memory usage. ([#528](https://github.com/Open-EO/openeo-python-client/issues/528))
 - `Connection.execute()` and `DataCube.execute()` now have a `auto_decode` argument. If set to True (default) the response will be decoded as a JSON and throw an exception if this fails, if set to False the raw `requests.Response` object will be returned. ([#499](https://github.com/Open-EO/openeo-python-client/issues/499))
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- Changed default `chunk_size` of various `download` functions from None to 10MB. This should improve download speed of large files.
+- Changed default `chunk_size` of various `download` functions from None to 10MB. This improves the handling of large downloads and reduces memory usage.
 - `Connection.execute()` and `DataCube.execute()` now have a `auto_decode` argument. If set to True (default) the response will be decoded as a JSON and throw an exception if this fails, if set to False the raw `requests.Response` object will be returned. ([#499](https://github.com/Open-EO/openeo-python-client/issues/499))
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-
+- Changed default `chunk_size` of various `download` functions from None to 10MB. This should improve download speed of large files.
 ### Removed
 
 ### Fixed

--- a/openeo/rest/__init__.py
+++ b/openeo/rest/__init__.py
@@ -2,6 +2,9 @@ from typing import Optional
 
 from openeo import BaseOpenEoException
 
+# TODO: get from config file
+DEFAULT_DOWNLOAD_CHUNK_SIZE = 10000000  # 10MB
+
 
 class OpenEoClientException(BaseOpenEoException):
     """Base class for OpenEO client exceptions"""

--- a/openeo/rest/__init__.py
+++ b/openeo/rest/__init__.py
@@ -3,7 +3,7 @@ from typing import Optional
 from openeo import BaseOpenEoException
 
 # TODO: get from config file
-DEFAULT_DOWNLOAD_CHUNK_SIZE = 10000000  # 10MB
+DEFAULT_DOWNLOAD_CHUNK_SIZE = 10_000_000  # 10MB
 
 
 class OpenEoClientException(BaseOpenEoException):

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -1540,8 +1540,10 @@ class Connection(RestApiConnection):
         self,
         graph: Union[dict, FlatGraphableMixin, str, Path],
         outputfile: Union[Path, str, None] = None,
+        *,
         timeout: Optional[int] = None,
         validate: Optional[bool] = None,
+        chunk_size: int = DEFAULT_DOWNLOAD_CHUNK_SIZE,
     ) -> Union[None, bytes]:
         """
         Downloads the result of a process graph synchronously,
@@ -1554,6 +1556,7 @@ class Connection(RestApiConnection):
         :param timeout: timeout to wait for response
         :param validate: Optional toggle to enable/prevent validation of the process graphs before execution
             (overruling the connection's ``auto_validate`` setting).
+        :param chunk_size: chunk size for streaming response.
         """
         pg_with_metadata = self._build_request_with_process_graph(process_graph=graph)
         self._preflight_validation(pg_with_metadata=pg_with_metadata, validate=validate)
@@ -1567,7 +1570,7 @@ class Connection(RestApiConnection):
 
         if outputfile is not None:
             with Path(outputfile).open(mode="wb") as f:
-                for chunk in response.iter_content(chunk_size=DEFAULT_DOWNLOAD_CHUNK_SIZE):
+                for chunk in response.iter_content(chunk_size=chunk_size):
                     f.write(chunk)
         else:
             return response.content

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -51,6 +51,7 @@ from openeo.rest.auth.oidc import (
     OidcRefreshTokenAuthenticator,
     OidcResourceOwnerPasswordAuthenticator,
 )
+from openeo.rest import DEFAULT_DOWNLOAD_CHUNK_SIZE
 from openeo.rest.datacube import DataCube, InputDate
 from openeo.rest.graph_building import CollectionProperty
 from openeo.rest.job import BatchJob, RESTJob
@@ -1566,7 +1567,7 @@ class Connection(RestApiConnection):
 
         if outputfile is not None:
             with Path(outputfile).open(mode="wb") as f:
-                for chunk in response.iter_content(chunk_size=10000000):
+                for chunk in response.iter_content(chunk_size=DEFAULT_DOWNLOAD_CHUNK_SIZE):
                     f.write(chunk)
         else:
             return response.content

--- a/openeo/rest/connection.py
+++ b/openeo/rest/connection.py
@@ -1566,7 +1566,7 @@ class Connection(RestApiConnection):
 
         if outputfile is not None:
             with Path(outputfile).open(mode="wb") as f:
-                for chunk in response.iter_content(chunk_size=None):
+                for chunk in response.iter_content(chunk_size=10000000):
                     f.write(chunk)
         else:
             return response.content

--- a/openeo/rest/job.py
+++ b/openeo/rest/job.py
@@ -351,13 +351,14 @@ class ResultAsset:
             n=self.name, t=self.metadata.get("type", "unknown"), h=self.href
         )
 
-    def download(self, target: Optional[Union[Path, str]] = None, chunk_size=None) -> Path:
+    def download(self, target: Optional[Union[Path, str]] = None, chunk_size=10000000) -> Path:
         """
         Download asset to given location
 
         :param target: download target path. Can be an existing folder
             (in which case the filename advertised by backend will be used)
             or full file name. By default, the working directory will be used.
+        :param chunk_size: size of chunks to download (in bytes). Default is 10MB
         """
         target = Path(target or Path.cwd())
         if target.is_dir():

--- a/openeo/rest/job.py
+++ b/openeo/rest/job.py
@@ -357,17 +357,17 @@ class ResultAsset:
             n=self.name, t=self.metadata.get("type", "unknown"), h=self.href
         )
 
-    def download(self, target: Optional[Union[Path, str]] = None, chunk_size: Optional[int] = None) -> Path:
+    def download(
+        self, target: Optional[Union[Path, str]] = None, *, chunk_size: int = DEFAULT_DOWNLOAD_CHUNK_SIZE
+    ) -> Path:
         """
         Download asset to given location
 
         :param target: download target path. Can be an existing folder
             (in which case the filename advertised by backend will be used)
             or full file name. By default, the working directory will be used.
-        :param chunk_size: size of chunks to download (in bytes). If None, connection.DEFAULT_DOWNLOAD_CHUNK_SIZE will be used.
+        :param chunk_size: chunk size for streaming response.
         """
-        if not chunk_size:
-            chunk_size = DEFAULT_DOWNLOAD_CHUNK_SIZE
         target = Path(target or Path.cwd())
         if target.is_dir():
             target = target / self.name

--- a/openeo/rest/job.py
+++ b/openeo/rest/job.py
@@ -19,7 +19,13 @@ from openeo.internal.jupyter import (
     render_error,
 )
 from openeo.internal.warnings import deprecated, legacy_alias
-from openeo.rest import JobFailedException, OpenEoApiError, OpenEoClientException, OpenEoApiPlainError
+from openeo.rest import (
+    JobFailedException,
+    OpenEoApiError,
+    OpenEoClientException,
+    OpenEoApiPlainError,
+    DEFAULT_DOWNLOAD_CHUNK_SIZE,
+)
 from openeo.util import ensure_dir
 
 if typing.TYPE_CHECKING:
@@ -351,15 +357,17 @@ class ResultAsset:
             n=self.name, t=self.metadata.get("type", "unknown"), h=self.href
         )
 
-    def download(self, target: Optional[Union[Path, str]] = None, chunk_size=10000000) -> Path:
+    def download(self, target: Optional[Union[Path, str]] = None, chunk_size: Optional[int] = None) -> Path:
         """
         Download asset to given location
 
         :param target: download target path. Can be an existing folder
             (in which case the filename advertised by backend will be used)
             or full file name. By default, the working directory will be used.
-        :param chunk_size: size of chunks to download (in bytes). Default is 10MB
+        :param chunk_size: size of chunks to download (in bytes). If None, connection.DEFAULT_DOWNLOAD_CHUNK_SIZE will be used.
         """
+        if not chunk_size:
+            chunk_size = DEFAULT_DOWNLOAD_CHUNK_SIZE
         target = Path(target or Path.cwd())
         if target.is_dir():
             target = target / self.name

--- a/openeo/rest/userfile.py
+++ b/openeo/rest/userfile.py
@@ -5,6 +5,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Optional, Union
 
 from openeo.util import ensure_dir
+from openeo.rest import DEFAULT_DOWNLOAD_CHUNK_SIZE
 
 if typing.TYPE_CHECKING:
     # Imports for type checking only (circular import issue at runtime).
@@ -66,7 +67,7 @@ class UserFile:
         ensure_dir(target.parent)
 
         with target.open(mode="wb") as f:
-            for chunk in response.iter_content(chunk_size=10000000):
+            for chunk in response.iter_content(chunk_size=DEFAULT_DOWNLOAD_CHUNK_SIZE):
                 f.write(chunk)
 
         return target

--- a/openeo/rest/userfile.py
+++ b/openeo/rest/userfile.py
@@ -66,7 +66,7 @@ class UserFile:
         ensure_dir(target.parent)
 
         with target.open(mode="wb") as f:
-            for chunk in response.iter_content(chunk_size=None):
+            for chunk in response.iter_content(chunk_size=10000000):
                 f.write(chunk)
 
         return target


### PR DESCRIPTION
issue #528
this affects response.iter_content in the following functions:
- openeo.rest.connection.Connection.download
- openeo.rest.job.Job.download
- openeo.rest.userfile.UserFile.download

in Job.download the chunk size can still be overwritten by the user