### PR TITLE
Use generic type definition in the openeo_process decorator

### DIFF
--- a/openeo/internal/documentation.py
+++ b/openeo/internal/documentation.py
@@ -12,7 +12,7 @@ from typing import Callable, Optional, Tuple, TypeVar
 _process_registry = collections.defaultdict(list)
 
 
-T = TypeVar("T")
+T = TypeVar("T", bound=Callable)
 
 
 def openeo_process(

--- a/openeo/internal/documentation.py
+++ b/openeo/internal/documentation.py
@@ -1,17 +1,23 @@
 """
 Utilities to build/automate/extend documentation
 """
+
 import collections
 import inspect
 import textwrap
 from functools import partial
-from typing import Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple, TypeVar
 
 # TODO: give this a proper public API?
 _process_registry = collections.defaultdict(list)
 
 
-def openeo_process(f: Optional[Callable] = None, process_id: Optional[str] = None, mode: Optional[str] = None):
+T = TypeVar("T")
+
+
+def openeo_process(
+    f: Optional[T] = None, process_id: Optional[str] = None, mode: Optional[str] = None
+) -> T:
     """
     Decorator for function or method to associate it with a standard openEO process
 


### PR DESCRIPTION
This improves static type checkers ability to infer typing.

Related to: #542 