### PR TITLE
 fix for broken `reduce_temporal` after `load_stac`

### DIFF
--- a/openeo/metadata.py
+++ b/openeo/metadata.py
@@ -581,5 +581,8 @@ def metadata_from_stac(url: str) -> CubeMetadata:
 
     # TODO: conditionally include band dimension when there was actual indication of band metadata?
     band_dimension = BandDimension(name="bands", bands=bands)
-    metadata = CubeMetadata(dimensions=[band_dimension])
+    # TODO: get actual temporal extent information from metadata (if any)
+    # TODO: is it possible to derive the actual name of temporal dimension that the backend will use?
+    temporal_dimension = TemporalDimension(name="t", extent=[None, None])
+    metadata = CubeMetadata(dimensions=[band_dimension, temporal_dimension])
     return metadata


### PR DESCRIPTION
Issue #567 initial fix for broken `reduce_temporal` after `load_stac`