### PR TITLE
Add testing utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add experimental `openeo.testing.results` subpackage with reusable test utilities for comparing batch job results with reference data
+
 ### Changed
 
 ### Removed

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -146,3 +146,21 @@ Various utilities and helpers to simplify the construction of openEO process gra
 
 .. automodule:: openeo.internal.graph_building
     :members: PGNode, FlatGraphableMixin
+
+
+Testing
+--------
+
+Various utilities for testing use cases (unit tests, integration tests, benchmarking, ...)
+
+openeo.testing
+``````````````
+
+.. automodule:: openeo.testing
+    :members:
+
+openeo.testing.results
+``````````````````````
+
+.. automodule:: openeo.testing.results
+    :members:

--- a/openeo/rest/job.py
+++ b/openeo/rest/job.py
@@ -35,6 +35,9 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_JOB_RESULTS_FILENAME = "job-results.json"
+
+
 class BatchJob:
     """
     Handle for an openEO batch job, allowing it to describe, start, cancel, inspect results, etc.
@@ -414,6 +417,9 @@ class JobResults:
     def __repr__(self):
         return "<JobResults for job {j!r}>".format(j=self._job.job_id)
 
+    def get_job_id(self) -> str:
+        return self._job.job_id
+
     def _repr_html_(self):
         try:
             response = self.get_metadata()
@@ -503,7 +509,7 @@ class JobResults:
 
         if include_stac_metadata:
             # TODO #184: convention for metadata file name?
-            metadata_file = target / "job-results.json"
+            metadata_file = target / DEFAULT_JOB_RESULTS_FILENAME
             # TODO #184: rewrite references to locally downloaded assets?
             metadata_file.write_text(json.dumps(self.get_metadata()))
             downloaded.append(metadata_file)

--- a/openeo/testing/__init__.py
+++ b/openeo/testing/__init__.py
@@ -11,14 +11,15 @@ class TestDataLoader:
     """
     Helper to resolve paths to test data files, load them as JSON, optionally preprocess them, etc.
 
-    It's intended to be used as a pytest fixture, e.g. from conftest.py:
+    It's intended to be used as a pytest fixture, e.g. from ``conftest.py``:
+
+    .. code-block:: python
 
         @pytest.fixture
         def test_data() -> TestDataLoader:
             return TestDataLoader(root=Path(__file__).parent / "data")
 
     .. versionadded:: 0.30.0
-
     """
 
     def __init__(self, root: Union[str, Path]):

--- a/openeo/testing/results.py
+++ b/openeo/testing/results.py
@@ -2,21 +2,86 @@
 Tools for matching actual results against expected reference data.
 """
 
-from typing import List, Optional
+import logging
+import tempfile
+from pathlib import Path
+from typing import List, Optional, Union
 
 import numpy
 import xarray
 
+from openeo.rest.job import DEFAULT_JOB_RESULTS_FILENAME, BatchJob, JobResults
 
-def compare_xarray(
-    actual: xarray.DataArray,
-    desired: xarray.DataArray,
+_log = logging.getLogger(__name__)
+
+
+_DEFAULT_RTOL = 1e-6
+_DEFAULT_ATOL = 1e-6
+
+
+def _load_xarray_netcdf(path: Union[str, Path], **kwargs) -> xarray.Dataset:
+    """
+    Load a netCDF file as Xarray Dataset
+    """
+    return xarray.load_dataset(path, **kwargs)
+
+
+def _load_rioxarray_geotiff(path: Union[str, Path], **kwargs) -> xarray.DataArray:
+    """
+    Load a GeoTIFF file as Xarray DataArray (using `rioxarray` extension).
+    """
+    try:
+        import rioxarray
+    except ImportError as e:
+        raise ImportError("This feature requires 'rioxarray` as optional dependency.") from e
+    return rioxarray.open_rasterio(path, **kwargs)
+
+
+def _load_xarray(path: Union[str, Path], **kwargs) -> Union[xarray.Dataset, xarray.DataArray]:
+    """
+    Generically load a netCDF/GeoTIFF file as Xarray Dataset/DataArray.
+    """
+    path = Path(path)
+    if path.suffix.lower() in {".nc", ".netcdf"}:
+        return _load_xarray_netcdf(path, **kwargs)
+    elif path.suffix.lower() in {".tif", ".tiff", ".gtiff", ".geotiff"}:
+        return _load_rioxarray_geotiff(path, **kwargs)
+    raise ValueError(f"Unsupported file type: {path}")
+
+
+def _as_xarray_dataset(data: Union[str, Path, xarray.Dataset]) -> xarray.Dataset:
+    """
+    Get data as Xarray Dataset (loading from file if needed).
+    """
+    if isinstance(data, (str, Path)):
+        data = _load_xarray(data)
+    # TODO auto-convert DataArray to Dataset?
+    if not isinstance(data, xarray.Dataset):
+        raise ValueError(f"Unsupported type: {type(data)}")
+    return data
+
+
+def _as_xarray_dataarray(data: Union[str, Path, xarray.DataArray]) -> xarray.DataArray:
+    """
+    Convert a path to a NetCDF/GeoTIFF file to an Xarray DataArray.
+
+    :param data: path to a NetCDF/GeoTIFF file or Xarray DataArray
+    :return: Xarray DataArray
+    """
+    if isinstance(data, (str, Path)):
+        data = _load_xarray(data)
+    # TODO: auto-convert Dataset to DataArray?
+    if not isinstance(data, xarray.DataArray):
+        raise ValueError(f"Unsupported type: {type(data)}")
+    return data
+
+
+def _compare_xarray_dataarray(
+    actual: Union[xarray.DataArray, str, Path],
+    expected: Union[xarray.DataArray, str, Path],
     *,
-    rtol: float = 1e-7,
-    atol: float = 0,
-    allowed_mismatch_fraction: float = 0,
-    allowed_mismatch_rtol: Optional[float] = None,
-    allowed_mismatch_atol: Optional[float] = None,
+    rtol: float = _DEFAULT_RTOL,
+    atol: float = _DEFAULT_ATOL,
 ) -> List[str]:
     """
     Compare two xarray DataArrays with tolerance and report mismatch issues (as strings)
@@ -25,55 +90,242 @@ def compare_xarray(
     - (optional) Check fraction of mismatching pixels (difference exceeding some tolerance).
       If fraction is below a given threshold, ignore these mismatches in subsequent comparisons.
       If fraction is above the threshold, report this issue.
-    - Compare actual and desired data with `numpy.testing.assert_allclose` and specified tolerances.
+    - Compare actual and expected data with `numpy.testing.assert_allclose` and specified tolerances.
 
-    :param actual: actual data
-    :param desired: expected data
-    :param rtol: relative tolerance
-    :param atol: absolute tolerance
-    :param allowed_mismatch_fraction: (optional) allowed fraction of mismatching elements to ignore
-    :param allowed_mismatch_rtol: relative tolerance for mismatched elements to ignore
-    :param allowed_mismatch_atol: absolute tolerance for mismatched elements to ignore
     :return: list of issues (empty if no issues)
     """
-    assert isinstance(actual, xarray.DataArray)
-    assert isinstance(desired, xarray.DataArray)
+    # TODO: make this a public function?
     # TODO: option for nodata fill value?
     # TODO: option to include data type check?
     # TODO: option to cast to some data type (or even rescale) before comparison?
+    actual = _as_xarray_dataarray(actual)
+    expected = _as_xarray_dataarray(expected)
     issues = []
 
-    # TODO: first compare dims, coords, ... and finally abort with check on shape
-
-    if actual.shape != desired.shape:
-        issues.append(f"Shape mismatch: {actual.shape} != {desired.shape}")
+    # TODO: isn't there functionality in Xarray itself to compare these aspects?
+    if actual.dims != expected.dims:
+        issues.append(f"Dimension mismatch: {actual.dims} != {expected.dims}")
+    for dim in set(expected.dims).intersection(actual.dims):
+        acs = actual.coords[dim].values
+        ecs = expected.coords[dim].values
+        if not (acs.shape == ecs.shape and (acs == ecs).all()):
+            issues.append(f"Coordinates mismatch for dimension {dim!r}: {acs} != {ecs}")
+    if actual.shape != expected.shape:
+        issues.append(f"Shape mismatch: {actual.shape} != {expected.shape}")
         # Abort: no point in comparing data if shapes do not match
         return issues
 
-    if allowed_mismatch_fraction:
-        # Ignore limited fraction of mismatches
-        if allowed_mismatch_rtol is None:
-            allowed_mismatch_rtol = rtol
-        if allowed_mismatch_atol is None:
-            allowed_mismatch_atol = atol
-        significantly_different = ~numpy.isclose(
-            actual, desired, rtol=allowed_mismatch_rtol, atol=allowed_mismatch_atol, equal_nan=True
-        )
-        mismatch_fraction = significantly_different.mean()
-        if mismatch_fraction > allowed_mismatch_fraction:
-            issues.append(
-                # TODO: include total counts in addition to fraction?
-                f"Fraction of mismatched elements is too large: {mismatch_fraction:.2%} > {allowed_mismatch_fraction:.2%}"
-            )
-        else:
-            # Ignore these mismatches in the following steps
-            actual = actual.where(~significantly_different)
-            desired = desired.where(~significantly_different)
-
     try:
-        numpy.testing.assert_allclose(actual=actual, desired=desired, rtol=rtol, atol=atol, equal_nan=True)
+        numpy.testing.assert_allclose(actual=actual, desired=expected, rtol=rtol, atol=atol, equal_nan=True)
     except AssertionError as e:
         # TODO: message of `assert_allclose` is typically multiline, split it again or make it one line?
         issues.append(str(e).strip())
 
     return issues
+
+
+def assert_xarray_dataarray_allclose(
+    actual: Union[xarray.DataArray, str, Path],
+    expected: Union[xarray.DataArray, str, Path],
+    *,
+    rtol: float = _DEFAULT_RTOL,
+    atol: float = _DEFAULT_ATOL,
+):
+    """
+    Assert that two Xarray ``DataArrays`` are almost equal (with tolerance).
+
+    :param actual: actual value
+    :param expected: expected or reference value
+    :param rtol: relative tolerance
+    :param atol: absolute tolerance
+    :raises AssertionError: if not equal within the given tolerance
+
+    .. warning::
+        This function is experimental and its API may change in the future.
+    """
+    issues = _compare_xarray_dataarray(actual=actual, expected=expected, rtol=rtol, atol=atol)
+    if issues:
+        raise AssertionError("\n".join(issues))
+
+
+def _compare_xarray_datasets(
+    actual: Union[xarray.Dataset, str, Path],
+    expected: Union[xarray.Dataset, str, Path],
+    *,
+    rtol: float = _DEFAULT_RTOL,
+    atol: float = _DEFAULT_ATOL,
+) -> List[str]:
+    """
+    Compare two xarray DataSets with tolerance and report mismatch issues (as strings)
+
+    :return: list of issues (empty if no issues)
+    """
+    # TODO: make this a public function?
+    actual = _as_xarray_dataset(actual)
+    expected = _as_xarray_dataset(expected)
+
+    all_issues = []
+    actual_vars = set(actual.data_vars)
+    expected_vars = set(expected.data_vars)
+    if actual_vars != expected_vars:
+        all_issues.append(f"Xarray DataSet variables mismatch: {actual_vars} != {expected_vars}")
+    for var in expected_vars.intersection(actual_vars):
+        issues = _compare_xarray_dataarray(actual[var], expected[var], rtol=rtol, atol=atol)
+        if issues:
+            all_issues.append(f"Issues for variable {var!r}:")
+            all_issues.extend(issues)
+    return all_issues
+
+
+def assert_xarray_dataset_allclose(
+    actual: Union[xarray.Dataset, str, Path],
+    expected: Union[xarray.Dataset, str, Path],
+    *,
+    rtol: float = _DEFAULT_RTOL,
+    atol: float = _DEFAULT_ATOL,
+):
+    """
+    Assert that two Xarray ``DataSets`` are almost equal (with tolerance).
+
+    :param actual: actual value
+    :param expected: expected or reference value
+    :param rtol: relative tolerance
+    :param atol: absolute tolerance
+    :raises AssertionError: if not equal within the given tolerance
+
+    .. warning::
+        This function is experimental and its API may change in the future.
+    """
+    issues = _compare_xarray_datasets(actual=actual, expected=expected, rtol=rtol, atol=atol)
+    if issues:
+        raise AssertionError("\n".join(issues))
+
+
+def assert_xarray_allclose(
+    actual: Union[xarray.Dataset, xarray.DataArray, str, Path],
+    expected: Union[xarray.Dataset, xarray.DataArray, str, Path],
+    *,
+    rtol: float = _DEFAULT_RTOL,
+    atol: float = _DEFAULT_ATOL,
+):
+    """
+    Assert that two Xarray ``DataSet``s or ``DataArray``s are equal (with tolerance).
+
+    :param actual: actual data array or dataset
+    :param expected: actual data array or dataset
+    :param rtol: relative tolerance
+    :param atol: absolute tolerance
+    :raises AssertionError: if not equal within the given tolerance
+
+    .. warning::
+        This function is experimental and its API may change in the future.
+    """
+    if isinstance(actual, (str, Path)):
+        actual = _load_xarray(actual)
+    if isinstance(expected, (str, Path)):
+        expected = _load_xarray(expected)
+
+    if isinstance(actual, xarray.Dataset) and isinstance(expected, xarray.Dataset):
+        assert_xarray_dataset_allclose(actual, expected, rtol=rtol, atol=atol)
+    elif isinstance(actual, xarray.DataArray) and isinstance(expected, xarray.DataArray):
+        assert_xarray_dataarray_allclose(actual, expected, rtol=rtol, atol=atol)
+    else:
+        raise ValueError(f"Unsupported types: {type(actual)} and {type(expected)}")
+
+
+def _as_job_results_download(
+    job_results: Union[BatchJob, JobResults, str, Path], tmp_path: Optional[Path] = None
+) -> Path:
+    """
+    Produce a directory with downloaded job results assets and metadata.
+
+    :param job_results: a batch job, job results metadata object or a path
+    :param tmp_path: root temp path to download results if needed
+    :return:
+    """
+    # TODO: support download/copy from other sources (e.g. S3, ...)
+    if isinstance(job_results, BatchJob):
+        job_results = job_results.get_results()
+    if isinstance(job_results, JobResults):
+        download_dir = tempfile.mkdtemp(dir=tmp_path, prefix=job_results.get_job_id() + "-")
+        _log.info(f"Downloading results from job {job_results.get_job_id()} to {download_dir}")
+        job_results.download_files(target=download_dir)
+        job_results = download_dir
+    if isinstance(job_results, (str, Path)):
+        return Path(job_results)
+    else:
+        raise ValueError(f"Unsupported type: {type(job_results)}")
+
+
+def _compare_job_results(
+    actual: Union[BatchJob, JobResults, str, Path],
+    expected: Union[BatchJob, JobResults, str, Path],
+    *,
+    rtol: float = _DEFAULT_RTOL,
+    atol: float = _DEFAULT_ATOL,
+    tmp_path: Optional[Path] = None,
+) -> List[str]:
+    """
+    Compare two job results sets (directories with downloaded assets and metadata,
+    e.g. as produced by ``JobResults.download_files()``)
+
+    :return: list of issues (empty if no issues)
+    """
+    actual_dir = _as_job_results_download(actual, tmp_path=tmp_path)
+    expected_dir = _as_job_results_download(expected, tmp_path=tmp_path)
+    _log.info(f"Comparing job results: {actual_dir!r} vs {expected_dir!r}")
+
+    all_issues = []
+
+    actual_filenames = set(p.name for p in actual_dir.glob("*") if p.is_file())
+    expected_filenames = set(p.name for p in expected_dir.glob("*") if p.is_file())
+    if actual_filenames != expected_filenames:
+        all_issues.append(f"File set mismatch: {actual_filenames} != {expected_filenames}")
+
+    for filename in expected_filenames.intersection(actual_filenames):
+        actual_path = actual_dir / filename
+        expected_path = expected_dir / filename
+        if filename == DEFAULT_JOB_RESULTS_FILENAME:
+            # TODO: check metadata (e.g. "derived_from" links)
+            ...
+        elif expected_path.suffix.lower() in {".nc", ".netcdf"}:
+            issues = _compare_xarray_datasets(actual=actual_path, expected=expected_path, rtol=rtol, atol=atol)
+            if issues:
+                all_issues.append(f"Issues for file {filename!r}:")
+                all_issues.extend(issues)
+        elif expected_path.suffix.lower() in {".tif", ".tiff", ".gtiff", ".geotiff"}:
+            issues = _compare_xarray_dataarray(actual=actual_path, expected=expected_path, rtol=rtol, atol=atol)
+            if issues:
+                all_issues.append(f"Issues for file {filename!r}:")
+                all_issues.extend(issues)
+        else:
+            _log.warning(f"Unhandled job result asset {filename!r}")
+
+    return all_issues
+
+
+def assert_job_results_allclose(
+    actual: Union[BatchJob, JobResults, str, Path],
+    expected: Union[BatchJob, JobResults, str, Path],
+    *,
+    rtol: float = _DEFAULT_RTOL,
+    atol: float = _DEFAULT_ATOL,
+    tmp_path: Optional[Path] = None,
+):
+    """
+    Assert that two job results sets are almost equal (with tolerance).
+
+    :param actual: actual job results (batch job, job results metadata object or a path)
+    :param expected: expected job results (batch job, job results metadata object or a path)
+    :param rtol: relative tolerance
+    :param atol: absolute tolerance
+    :param tmp_path: root temp path to download results if needed.
+        It's recommended to pass pytest's `tmp_path` fixture here
+    :raises AssertionError: if not equal within the given tolerance
+
+    .. warning::
+        This function is experimental and its API may change in the future.
+    """
+    issues = _compare_job_results(actual, expected, rtol=rtol, atol=atol, tmp_path=tmp_path)
+    if issues:
+        raise AssertionError("\n".join(issues))

--- a/openeo/testing/results.py
+++ b/openeo/testing/results.py
@@ -1,5 +1,5 @@
 """
-Tools for matching actual results against expected reference data.
+Assert functions for comparing actual (batch job) results against expected reference data.
 """
 
 import logging
@@ -132,16 +132,18 @@ def assert_xarray_dataarray_allclose(
     atol: float = _DEFAULT_ATOL,
 ):
     """
-    Assert that two Xarray ``DataArrays`` are almost equal (with tolerance).
+    Assert that two Xarray ``DataArray`` instances are equal (with tolerance).
 
-    :param actual: actual value
-    :param expected: expected or reference value
+    :param actual: actual data
+    :param expected: expected or reference data
     :param rtol: relative tolerance
     :param atol: absolute tolerance
     :raises AssertionError: if not equal within the given tolerance
 
+    .. versionadded:: 0.31.0
+
     .. warning::
-        This function is experimental and its API may change in the future.
+        This function is experimental and subject to change.
     """
     issues = _compare_xarray_dataarray(actual=actual, expected=expected, rtol=rtol, atol=atol)
     if issues:
@@ -156,7 +158,7 @@ def _compare_xarray_datasets(
     atol: float = _DEFAULT_ATOL,
 ) -> List[str]:
     """
-    Compare two xarray DataSets with tolerance and report mismatch issues (as strings)
+    Compare two xarray ``DataSet``s with tolerance and report mismatch issues (as strings)
 
     :return: list of issues (empty if no issues)
     """
@@ -185,16 +187,18 @@ def assert_xarray_dataset_allclose(
     atol: float = _DEFAULT_ATOL,
 ):
     """
-    Assert that two Xarray ``DataSets`` are almost equal (with tolerance).
+    Assert that two Xarray ``DataSet`` instances are equal (with tolerance).
 
-    :param actual: actual value
-    :param expected: expected or reference value
+    :param actual: actual data
+    :param expected: expected or reference data
     :param rtol: relative tolerance
     :param atol: absolute tolerance
     :raises AssertionError: if not equal within the given tolerance
 
+    .. versionadded:: 0.31.0
+
     .. warning::
-        This function is experimental and its API may change in the future.
+        This function is experimental and subject to change.
     """
     issues = _compare_xarray_datasets(actual=actual, expected=expected, rtol=rtol, atol=atol)
     if issues:
@@ -209,7 +213,7 @@ def assert_xarray_allclose(
     atol: float = _DEFAULT_ATOL,
 ):
     """
-    Assert that two Xarray ``DataSet``s or ``DataArray``s are equal (with tolerance).
+    Assert that two Xarray ``DataSet`` or ``DataArray`` instances are equal (with tolerance).
 
     :param actual: actual data array or dataset
     :param expected: actual data array or dataset
@@ -217,8 +221,10 @@ def assert_xarray_allclose(
     :param atol: absolute tolerance
     :raises AssertionError: if not equal within the given tolerance
 
+    .. versionadded:: 0.31.0
+
     .. warning::
-        This function is experimental and its API may change in the future.
+        This function is experimental and subject to change.
     """
     if isinstance(actual, (str, Path)):
         actual = _load_xarray(actual)
@@ -313,7 +319,7 @@ def assert_job_results_allclose(
     tmp_path: Optional[Path] = None,
 ):
     """
-    Assert that two job results sets are almost equal (with tolerance).
+    Assert that two job results sets are equal (with tolerance).
 
     :param actual: actual job results (batch job, job results metadata object or a path)
     :param expected: expected job results (batch job, job results metadata object or a path)
@@ -323,8 +329,10 @@ def assert_job_results_allclose(
         It's recommended to pass pytest's `tmp_path` fixture here
     :raises AssertionError: if not equal within the given tolerance
 
+    .. versionadded:: 0.31.0
+
     .. warning::
-        This function is experimental and its API may change in the future.
+        This function is experimental and subject to change.
     """
     issues = _compare_job_results(actual, expected, rtol=rtol, atol=atol, tmp_path=tmp_path)
     if issues:

--- a/openeo/testing/results.py
+++ b/openeo/testing/results.py
@@ -1,0 +1,79 @@
+"""
+Tools for matching actual results against expected reference data.
+"""
+
+from typing import List, Optional
+
+import numpy
+import xarray
+
+
+def compare_xarray(
+    actual: xarray.DataArray,
+    desired: xarray.DataArray,
+    *,
+    rtol: float = 1e-7,
+    atol: float = 0,
+    allowed_mismatch_fraction: float = 0,
+    allowed_mismatch_rtol: Optional[float] = None,
+    allowed_mismatch_atol: Optional[float] = None,
+) -> List[str]:
+    """
+    Compare two xarray DataArrays with tolerance and report mismatch issues (as strings)
+
+    Checks that are done (with tolerance):
+    - (optional) Check fraction of mismatching pixels (difference exceeding some tolerance).
+      If fraction is below a given threshold, ignore these mismatches in subsequent comparisons.
+      If fraction is above the threshold, report this issue.
+    - Compare actual and desired data with `numpy.testing.assert_allclose` and specified tolerances.
+
+    :param actual: actual data
+    :param desired: expected data
+    :param rtol: relative tolerance
+    :param atol: absolute tolerance
+    :param allowed_mismatch_fraction: (optional) allowed fraction of mismatching elements to ignore
+    :param allowed_mismatch_rtol: relative tolerance for mismatched elements to ignore
+    :param allowed_mismatch_atol: absolute tolerance for mismatched elements to ignore
+    :return: list of issues (empty if no issues)
+    """
+    assert isinstance(actual, xarray.DataArray)
+    assert isinstance(desired, xarray.DataArray)
+    # TODO: option for nodata fill value?
+    # TODO: option to include data type check?
+    # TODO: option to cast to some data type (or even rescale) before comparison?
+    issues = []
+
+    # TODO: first compare dims, coords, ... and finally abort with check on shape
+
+    if actual.shape != desired.shape:
+        issues.append(f"Shape mismatch: {actual.shape} != {desired.shape}")
+        # Abort: no point in comparing data if shapes do not match
+        return issues
+
+    if allowed_mismatch_fraction:
+        # Ignore limited fraction of mismatches
+        if allowed_mismatch_rtol is None:
+            allowed_mismatch_rtol = rtol
+        if allowed_mismatch_atol is None:
+            allowed_mismatch_atol = atol
+        significantly_different = ~numpy.isclose(
+            actual, desired, rtol=allowed_mismatch_rtol, atol=allowed_mismatch_atol, equal_nan=True
+        )
+        mismatch_fraction = significantly_different.mean()
+        if mismatch_fraction > allowed_mismatch_fraction:
+            issues.append(
+                # TODO: include total counts in addition to fraction?
+                f"Fraction of mismatched elements is too large: {mismatch_fraction:.2%} > {allowed_mismatch_fraction:.2%}"
+            )
+        else:
+            # Ignore these mismatches in the following steps
+            actual = actual.where(~significantly_different)
+            desired = desired.where(~significantly_different)
+
+    try:
+        numpy.testing.assert_allclose(actual=actual, desired=desired, rtol=rtol, atol=atol, equal_nan=True)
+    except AssertionError as e:
+        # TODO: message of `assert_allclose` is typically multiline, split it again or make it one line?
+        issues.append(str(e).strip())
+
+    return issues

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ tests_require = [
     "flake8>=5.0.0",
     "time_machine",
     "pyproj>=3.2.0",  # Pyproj is an optional, best-effort runtime dependency
+    "dirty_equals>=0.6.0",
+    # (#578) On Python 3.7: avoid dirty_equals 0.7.1 which wrongly claims to be Python 3.7 compatible
+    "dirty_equals<0.7.1 ; python_version <= '3.7'",
 ]
 
 docs_require = [

--- a/tests/testing/test_results.py
+++ b/tests/testing/test_results.py
@@ -1,0 +1,286 @@
+import re
+
+import dirty_equals
+import numpy
+import pytest
+import xarray
+
+from openeo.testing.results import compare_xarray
+
+
+class TestCompareXarray:
+    def test_simple_defaults(self):
+        desired = xarray.DataArray([1, 2, 3])
+        actual = xarray.DataArray([1, 2, 3])
+        issues = compare_xarray(actual, desired)
+        assert issues == []
+
+    @pytest.mark.parametrize(
+        ["actual", "expected"],
+        [
+            (xarray.DataArray([1, 2, 3, 4]), ["Shape mismatch: (4,) != (3,)"]),
+            (xarray.DataArray([[1, 2, 3], [4, 5, 6]]), ["Shape mismatch: (2, 3) != (3,)"]),
+            (xarray.DataArray([[1], [2], [3]]), ["Shape mismatch: (3, 1) != (3,)"]),
+        ],
+    )
+    def test_simple_shape_mismatch(self, actual, expected):
+        desired = xarray.DataArray([1, 2, 3])
+        assert compare_xarray(actual=actual, desired=desired) == expected
+
+    @pytest.mark.parametrize(
+        ["actual", "rtol", "expected"],
+        [
+            (xarray.DataArray([1, 2, 3.0000001]), 1e-6, []),
+            (
+                xarray.DataArray([1, 2, 3.00001]),
+                1e-6,
+                [
+                    dirty_equals.IsStr(
+                        regex=r"Not equal to tolerance rtol=1e-06, atol=0\s.*Mismatched elements: 1 / 3\s.*Max absolute difference.*?: 1\.e-05\s.*",
+                        regex_flags=re.DOTALL,
+                    )
+                ],
+            ),
+            (xarray.DataArray([1, 2, 3.001]), 0.1, []),
+        ],
+    )
+    def test_simple_rtol(self, actual, rtol, expected):
+        desired = xarray.DataArray([1, 2, 3])
+        assert compare_xarray(actual=actual, desired=desired, rtol=rtol) == expected
+
+    @pytest.mark.parametrize(
+        ["actual", "atol", "expected"],
+        [
+            (xarray.DataArray([1, 2, 3.001]), 0.01, []),
+            (
+                xarray.DataArray([1, 2, 3.1]),
+                0.1,
+                [
+                    dirty_equals.IsStr(
+                        regex=r"Not equal to tolerance rtol=0, atol=0\.1\s.*Mismatched elements: 1 / 3\s.*Max absolute difference.*?: 0\.1\s.*",
+                        regex_flags=re.DOTALL,
+                    )
+                ],
+            ),
+            (xarray.DataArray([1, 2, 3.1]), 0.2, []),
+        ],
+    )
+    def test_simple_atol(self, actual, atol, expected):
+        desired = xarray.DataArray([1, 2, 3])
+        assert compare_xarray(actual=actual, desired=desired, rtol=0, atol=atol) == expected
+
+    @pytest.mark.parametrize(
+        ["allowed_mismatch_fraction", "expected"],
+        [
+            (0.1, []),
+            (
+                0.01,
+                [
+                    "Fraction of mismatched elements is too large: 6.00% > 1.00%",
+                    dirty_equals.IsStr(
+                        regex=r"Not equal to tolerance rtol=1e-07, atol=0\s.*Mismatched elements: 6 / 100\s.*Max absolute difference.*?: 1\.\s.*",
+                        regex_flags=re.DOTALL,
+                    ),
+                ],
+            ),
+        ],
+    )
+    def test_allowed_mismatch_fraction(self, allowed_mismatch_fraction, expected):
+        desired = xarray.DataArray(numpy.ones((10, 10)))
+        actual = xarray.DataArray(numpy.ones((10, 10)))
+        actual[1:3, 1:4] = 2
+        assert (
+            compare_xarray(
+                actual=actual,
+                desired=desired,
+                allowed_mismatch_fraction=allowed_mismatch_fraction,
+            )
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        ["rtol", "allowed_mismatch_fraction", "allowed_mismatch_rtol", "expected"],
+        [
+            pytest.param(2, 0.01, 2, [], id="generous-rtols"),
+            pytest.param(0.11, 0.1, 0.2, [], id="just-below-radar"),
+            pytest.param(
+                0.01,
+                0.1,
+                0.5,
+                [
+                    dirty_equals.IsStr(
+                        regex=r"Not equal to tolerance rtol=0\.01, atol=0\s.*Mismatched elements: 16 / 100\s.*Max absolute difference.*?: 0\.1\s.*",
+                        regex_flags=re.DOTALL,
+                    )
+                ],
+                id="tight-rtol",
+            ),
+            pytest.param(
+                0.01,
+                0.01,
+                0.5,
+                [
+                    "Fraction of mismatched elements is too large: 6.00% > 1.00%",
+                    dirty_equals.IsStr(
+                        regex=r"Not equal to tolerance rtol=0\.01, atol=0\s.*Mismatched elements: 22 / 100\s.*Max absolute difference.*?: 1\.\s.*",
+                        regex_flags=re.DOTALL,
+                    ),
+                ],
+                id="tight-rtol-and-fraction",
+            ),
+            pytest.param(
+                2,
+                0.1,
+                0.01,
+                ["Fraction of mismatched elements is too large: 22.00% > 10.00%"],
+                id="tight-allowed-rtol",
+            ),
+            pytest.param(0.001, 0.3, 0.09, [], id="generous-allowed-rtol"),
+            pytest.param(0.2, 0.1, None, [], id="default-allowed-rtol-just-below-radar"),
+            pytest.param(
+                0.2,
+                0.01,
+                None,
+                [
+                    "Fraction of mismatched elements is too large: 6.00% > 1.00%",
+                    dirty_equals.IsStr(
+                        regex=r"Not equal to tolerance rtol=0\.2, atol=0\s.*Mismatched elements: 6 / 100\s.*Max absolute difference.*?: 1\.\s.*",
+                        regex_flags=re.DOTALL,
+                    ),
+                ],
+                id="default-allowed-rtol-with-small-allowed-fraction",
+            ),
+            pytest.param(
+                0.08,
+                0.1,
+                None,
+                [
+                    "Fraction of mismatched elements is too large: 22.00% > 10.00%",
+                    dirty_equals.IsStr(
+                        regex=r"Not equal to tolerance rtol=0\.08, atol=0\s.*Mismatched elements: 22 / 100\s.*Max absolute difference.*?: 1\.\s.*",
+                        regex_flags=re.DOTALL,
+                    ),
+                ],
+                id="default-allowed-rtol-with-tight-rtol",
+            ),
+        ],
+    )
+    def test_allowed_mismatch_fraction_with_rtol(
+        self, rtol, allowed_mismatch_fraction, allowed_mismatch_rtol, expected
+    ):
+        desired = xarray.DataArray(numpy.ones((10, 10)))
+        actual = xarray.DataArray(numpy.ones((10, 10)))
+        actual[1:3, 1:4] = 2
+        actual[5:9, 5:9] = 1.1
+        assert (
+            compare_xarray(
+                actual=actual,
+                desired=desired,
+                rtol=rtol,
+                atol=0,
+                allowed_mismatch_fraction=allowed_mismatch_fraction,
+                allowed_mismatch_rtol=allowed_mismatch_rtol,
+                allowed_mismatch_atol=0,
+            )
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        ["atol", "allowed_mismatch_fraction", "allowed_mismatch_atol", "expected"],
+        [
+            pytest.param(2, 0.01, 2, [], id="generous-atols"),
+            pytest.param(0.11, 0.1, 0.25, [], id="just-below-radar"),
+            pytest.param(
+                0.012,
+                0.1,
+                0.5,
+                [
+                    dirty_equals.IsStr(
+                        regex=r"Not equal to tolerance rtol=0, atol=0\.012\s.*Mismatched elements: 16 / 100\s.*Max absolute difference.*?: 0\.1\s.*",
+                        regex_flags=re.DOTALL,
+                    )
+                ],
+                id="tight-atol",
+            ),
+            pytest.param(
+                0.012,
+                0.01,
+                0.5,
+                [
+                    "Fraction of mismatched elements is too large: 6.00% > 1.00%",
+                    dirty_equals.IsStr(
+                        regex=r"Not equal to tolerance rtol=0, atol=0.012\s.*Mismatched elements: 22 / 100\s.*Max absolute difference.*?: 1\.\s.*",
+                        regex_flags=re.DOTALL,
+                    ),
+                ],
+                id="tight-atol-and-fraction",
+            ),
+            pytest.param(
+                2,
+                0.1,
+                0.01,
+                ["Fraction of mismatched elements is too large: 22.00% > 10.00%"],
+                id="tight-allowed-atol",
+            ),
+            pytest.param(0.001, 0.3, 0.09, [], id="generous-allowed-atol"),
+            pytest.param(0.2, 0.1, None, [], id="default-allowed-atol-just-below-radar"),
+            pytest.param(
+                0.2,
+                0.01,
+                None,
+                [
+                    "Fraction of mismatched elements is too large: 6.00% > 1.00%",
+                    dirty_equals.IsStr(
+                        regex=r"Not equal to tolerance rtol=0, atol=0\.2\s.*Mismatched elements: 6 / 100\s.*Max absolute difference.*?: 1\.\s.*",
+                        regex_flags=re.DOTALL,
+                    ),
+                ],
+                id="default-allowed-atol-with-small-allowed-fraction",
+            ),
+            pytest.param(
+                0.08,
+                0.1,
+                None,
+                [
+                    "Fraction of mismatched elements is too large: 22.00% > 10.00%",
+                    dirty_equals.IsStr(
+                        regex=r"Not equal to tolerance rtol=0, atol=0\.08\s.*Mismatched elements: 22 / 100\s.*Max absolute difference.*?: 1\.\s.*",
+                        regex_flags=re.DOTALL,
+                    ),
+                ],
+                id="default-allowed-rtol-with-tight-atol",
+            ),
+        ],
+    )
+    def test_allowed_mismatch_fraction_with_atol(
+        self, atol, allowed_mismatch_fraction, allowed_mismatch_atol, expected
+    ):
+        desired = xarray.DataArray(numpy.ones((10, 10)))
+        actual = xarray.DataArray(numpy.ones((10, 10)))
+        actual[1:3, 1:4] = 2
+        actual[5:9, 5:9] = 1.1
+        assert (
+            compare_xarray(
+                actual=actual,
+                desired=desired,
+                rtol=0,
+                atol=atol,
+                allowed_mismatch_fraction=allowed_mismatch_fraction,
+                allowed_mismatch_rtol=0,
+                allowed_mismatch_atol=allowed_mismatch_atol,
+            )
+            == expected
+        )
+
+    def test_nan_handling(self):
+        desired = xarray.DataArray([1, 2, numpy.nan, 4, float("nan")])
+        actual = xarray.DataArray([1, 2, numpy.nan, 4.001, float("nan")])
+
+        assert compare_xarray(actual, desired, rtol=0, atol=0.01) == []
+        assert compare_xarray(actual, desired, rtol=0, atol=0.0001) == [
+            dirty_equals.IsStr(
+                regex=r"Not equal to tolerance rtol=0, atol=0\.0001\s.*Mismatched elements: 1 / 5\s.*Max absolute difference.*?: 0\.001\s.*",
+                regex_flags=re.DOTALL,
+            ),
+        ]
+        assert compare_xarray(actual, desired, rtol=0, atol=0.0001, allowed_mismatch_fraction=0.21) == []


### PR DESCRIPTION
this PR adds testing utilities under `openeo.testing`, in particular `openeo.testing.results` to easily have assert functions to compare job results against reference data

relate to ESA-APEx/apex_algorithms#5