### PR TITLE
Add Json default for serialising Path objects

### DIFF
--- a/openeo/util.py
+++ b/openeo/util.py
@@ -462,6 +462,17 @@ def load_json_resource(src: Union[str, Path]) -> dict:
     raise ValueError(src)
 
 
+def json_default(obj: Any) -> Any:
+    """default function for packing objects in JSON."""
+    # This function could cover more cases like jupyter's implementation does:
+    # https://github.com/jupyter/jupyter_client/blob/main/jupyter_client/jsonutil.py#L108
+
+    if isinstance(obj, Path):
+        return str(obj)
+
+    raise TypeError("%r is not JSON serializable" % obj)
+
+
 class LazyLoadCache:
     """Simple cache that allows to (lazy) load on cache miss."""
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -29,6 +29,7 @@ from openeo.util import (
     ensure_list,
     first_not_none,
     guess_format,
+    json_default,
     normalize_crs,
     repr_truncate,
     rfc3339,
@@ -611,6 +612,19 @@ def test_guess_format():
     assert guess_format("./folder/file.geotiff") == "GTiff"
     assert guess_format("/folder/file.png") == "PNG"
     assert guess_format("../folder/file.notaformat") == "NOTAFORMAT"
+
+
+@pytest.mark.parametrize(
+    ["value", "expected"],
+    [
+        (3.1415, 3.1415),
+        (pathlib.Path("/tmp"), "/tmp"),
+        (pathlib.PosixPath("/tmp"), "/tmp"),
+    ],
+)
+def test_json_default(value, expected):
+    out = json.loads(json.dumps(value, default=json_default))
+    assert out == expected
 
 
 class TestLazyLoadCache:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -619,7 +619,8 @@ def test_guess_format():
     [
         (3.1415, 3.1415),
         (pathlib.Path("/tmp"), "/tmp"),
-        (pathlib.PosixPath("/tmp"), "/tmp"),
+        # PosixPath is not available on Windows, but is a subclass of Path, so the previous test is enough
+        # (pathlib.PosixPath("/tmp"), "/tmp"),
     ],
 )
 def test_json_default(value, expected):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -618,9 +618,9 @@ def test_guess_format():
     ["value", "expected"],
     [
         (3.1415, 3.1415),
-        (pathlib.Path("/tmp"), "/tmp"),
+        (pathlib.Path("tmp"), "tmp"),
         # PosixPath is not available on Windows, but is a subclass of Path, so the previous test is enough
-        # (pathlib.PosixPath("/tmp"), "/tmp"),
+        # (pathlib.PosixPath("tmp"), "tmp"),
     ],
 )
 def test_json_default(value, expected):


### PR DESCRIPTION
After this MR, `batch_job.py` in `openeo-geopyspark-driver` needs to be updated