### PR TITLE
add 500 to retry list

### DIFF
--- a/openeo/extra/job_management.py
+++ b/openeo/extra/job_management.py
@@ -234,7 +234,7 @@ class MultiBackendJobManager:
         504 Gateway Timeout
         """
         # TODO: refactor this helper out of this class and unify with `openeo_driver.util.http.requests_with_retry`
-        status_forcelist = [502, 503, 504]
+        status_forcelist = [500, 502, 503, 504]
         retries = Retry(
             total=MAX_RETRIES,
             read=MAX_RETRIES,


### PR DESCRIPTION
openEO on cdse also throws 500, job manager should not immediately give up, but continue with retrying https://github.com/Open-EO/openeo-python-client/issues/624