### PR TITLE
job manager tests: fail on any warning

### DIFF
--- a/tests/extra/test_job_management.py
+++ b/tests/extra/test_job_management.py
@@ -38,6 +38,13 @@ from openeo.extra.job_management import (
 from openeo.rest._testing import OPENEO_BACKEND, DummyBackend, build_capabilities
 from openeo.util import rfc3339
 
+# Module level markers
+pytestmark = [
+    # Fail on all warnings (except our own deprecation warnings)
+    pytest.mark.filterwarnings("error"),
+    pytest.mark.filterwarnings("default:.*`output_file` argument is deprecated.*:DeprecationWarning"),
+]
+
 
 @pytest.fixture
 def con(requests_mock) -> openeo.Connection:
@@ -77,8 +84,6 @@ def sleep_mock():
         yield sleep
 
 
-@pytest.mark.filterwarnings("default:.*`output_file` argument is deprecated.*:DeprecationWarning")
-@pytest.mark.filterwarnings("error")
 class TestMultiBackendJobManager:
 
     @pytest.fixture


### PR DESCRIPTION
Attempt to harden the job manager tests: fail hard on any warning (except our own deprecation warnings)

related to #641, #656