### PR TITLE
test: adapt unittest to assert new warnings of c59fe34d…

### DIFF
--- a/tests/rest/test_connection.py
+++ b/tests/rest/test_connection.py
@@ -3137,12 +3137,21 @@ class TestLoadStac:
     @pytest.mark.parametrize(
         ["bands", "has_band_dimension", "expected_pg_args", "expected_warnings"],
         [
-            (None, False, {}, ["bands_from_stac_collection: no band name source found"]),
+            (
+                None,
+                False,
+                {},
+                [
+                    "bands_from_stac_collection: consulting items for band metadata",
+                    "bands_from_stac_collection: no band name source found",
+                ],
+            ),
             (
                 ["B02", "B03"],
                 True,
                 {"bands": ["B02", "B03"]},
                 [
+                    "bands_from_stac_collection: consulting items for band metadata",
                     "bands_from_stac_collection: no band name source found",
                     "Bands ['B02', 'B03'] were specified in `load_stac`, but no band dimension was detected in the STAC metadata. Working with band dimension and specified bands.",
                 ],

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1223,7 +1223,9 @@ class TestStacMetadataParser:
                     Band("B04", common_name="red", wavelength_um=0.665),
                     Band("B03", common_name="green", wavelength_um=0.560),
                 ],
-                [],
+                [
+                    "bands_from_stac_catalog with summaries.keys()=dict_keys(['eo:bands']) (which is non-standard)",
+                ],
             ),
             (
                 {
@@ -1243,7 +1245,10 @@ class TestStacMetadataParser:
                     Band("B04", common_name="red", wavelength_um=0.665),
                     Band("B03", common_name="green", wavelength_um=0.560),
                 ],
-                ["Using 'eo:bands' metadata, but STAC extension eo was not declared."],
+                [
+                    "bands_from_stac_catalog with summaries.keys()=dict_keys(['eo:bands']) (which is non-standard)",
+                    "Using 'eo:bands' metadata, but STAC extension eo was not declared.",
+                ],
             ),
             (
                 {
@@ -1260,7 +1265,9 @@ class TestStacMetadataParser:
                     "links": [],
                 },
                 [Band("B04"), Band("B03")],
-                [],
+                [
+                    "bands_from_stac_catalog with summaries.keys()=dict_keys(['bands']) (which is non-standard)",
+                ],
             ),
             (
                 {
@@ -1280,7 +1287,9 @@ class TestStacMetadataParser:
                     Band("B04", common_name="red", wavelength_um=0.665),
                     Band("B03", common_name="green", wavelength_um=0.560),
                 ],
-                [],
+                [
+                    "bands_from_stac_catalog with summaries.keys()=dict_keys(['bands']) (which is non-standard)",
+                ],
             ),
         ],
     )
@@ -1384,7 +1393,9 @@ class TestStacMetadataParser:
                 },
                 {},
                 [Band("B02"), Band("B03")],
-                [],
+                [
+                    "bands_from_stac_collection: consulting items for band metadata",
+                ],
             ),
             (
                 # Collection with two items with different bands (eo:bands metadata)
@@ -1413,7 +1424,9 @@ class TestStacMetadataParser:
                 },
                 {},
                 [Band("B02"), Band("B03")],
-                [],
+                [
+                    "bands_from_stac_collection: consulting items for band metadata",
+                ],
             ),
             (
                 # Collection with two items with different bands in different metadata format
@@ -1441,7 +1454,9 @@ class TestStacMetadataParser:
                 },
                 {},
                 [Band("B02"), Band("B03")],
-                [],
+                [
+                    "bands_from_stac_collection: consulting items for band metadata",
+                ],
             ),
             (
                 # Collection with one item, with band metadata in asset
@@ -1466,7 +1481,9 @@ class TestStacMetadataParser:
                 },
                 {},
                 [Band("B02")],
-                [],
+                [
+                    "bands_from_stac_collection: consulting items for band metadata",
+                ],
             ),
             (
                 # Collection with multiple items and assets, only partially with band metadata
@@ -1497,7 +1514,9 @@ class TestStacMetadataParser:
                 },
                 {},
                 [Band("B02")],
-                [],
+                [
+                    "bands_from_stac_collection: consulting items for band metadata",
+                ],
             ),
         ],
     )


### PR DESCRIPTION
…442f919aef18313d1752ea404ead27da

This is for the broken unittests in https://github.com/Open-EO/openeo-python-client/issues/788