### PR TITLE
feature: handle expired token gracefully for artifact helper

### DIFF
--- a/openeo/extra/artifacts/_s3sts/sts.py
+++ b/openeo/extra/artifacts/_s3sts/sts.py
@@ -35,6 +35,8 @@ class OpenEOSTSClient:
         auth_token = auth.bearer.split("/")
 
         try:
+            # Do an API call with OpenEO to trigger a refresh of our token if it were stale.
+            connection.describe_account()
             return AWSSTSCredentials.from_assume_role_response(
                 self._get_sts_client().assume_role_with_web_identity(
                     RoleArn=self._get_aws_access_role(),
@@ -53,8 +55,6 @@ class OpenEOSTSClient:
                 _log.info(f"Retrying STS access in {sleep_ms} ms")
                 time.sleep(sleep_ms / 1000.0)
                 attempt += 1
-                # Do an API call with OpenEO to trigger a refresh of our token.
-                connection.describe_account()
                 _log.info(f"Retrying to get credentials for STS access {attempt}/{self._MAX_STS_ATTEMPTS}")
                 return self.assume_from_openeo_connection(connection, attempt)
             else:

--- a/tests/extra/artifacts/_s3sts/test_s3sts.py
+++ b/tests/extra/artifacts/_s3sts/test_s3sts.py
@@ -92,6 +92,7 @@ def conn_with_s3sts_capabilities(
     requests_mock, extra_api_capabilities, advertised_s3sts_config
 ) -> Iterator[Connection]:
     requests_mock.get(API_URL, json={"api_version": "1.0.0", **extra_api_capabilities})
+    requests_mock.get(f"{API_URL}me", json={})
     conn = Connection(API_URL)
     conn.auth = BearerAuth("oidc/fake/token")
     yield conn


### PR DESCRIPTION
If a token is expired we can refresh it by doing another OpenEO interaction. By allowing 3 attempts for the STS service and by doing a very wide except clause we also make ourselves more robust against intermittent errors.