### PR TITLE
issue406 add statistics to band class

### DIFF
--- a/openeo/metadata.py
+++ b/openeo/metadata.py
@@ -124,6 +124,7 @@ class Band(NamedTuple):
     aliases: Optional[List[str]] = None
     # "openeo:gsd" field (https://github.com/Open-EO/openeo-stac-extensions#GSD-Object)
     gsd: Optional[dict] = None
+    statistics: Optional[dict] = None
 
 
 class BandDimension(Dimension):


### PR DESCRIPTION
With the changes of https://github.com/Open-EO/openeo-geotrellis-extensions/issues/406, the metadata of the assets have a bands will a field` bands` that contains statistics instead of the `raster:bands` field.  When trying to download the results (j-25102008133547d8a8deeb00481658b0), an error happens: `TypeError("Band.__new__() got an unexpected keyword argument 'statistics'")`  (r-2510211238334676a70a5ae8dd8ae81a)
Adding statistics to the Band class should fix this