### PR TITLE
Issue840 splitting custom states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `MultiBackendJobManager`: add a dedicated `backend_status` column to job databases that exclusively holds the official openEO backend-reported job status (`created`, `queued`, `running`, `finished`, `error`, `canceled`). The existing `status` column continues to carry the full user-visible lifecycle, including internal housekeeping values (`not_started`, `queued_for_start`, `start_failed`, `skipped`, …) and any custom states added by users (e.g. `downloading`). This separates internal kitchen from public API, resolving a long-standing source of race conditions and test flakiness ([#840](https://github.com/Open-EO/openeo-python-client/issues/840))
+- `JobDatabaseInterface.get_by_status()` and `count_by_status()`: add optional `column` parameter (default `"status"`) to allow querying against either the user-visible `status` column or the new `backend_status` column
+
 ### Changed
+
+- `MultiBackendJobManager` internal job tracking now queries `backend_status` when determining which jobs are active on a backend (capacity calculation and `_track_statuses` polling), cleanly separating backend queries from internal lifecycle state
 
 ### Removed
 
 ### Fixed
+
+- `MultiBackendJobManager`: eliminate the race condition where `_track_statuses` could overwrite the internal `queued_for_start` state with `created` while the job-start thread was still in-flight ([#840](https://github.com/Open-EO/openeo-python-client/issues/840))
 
 
 ## [0.47.0] - 2025-12-17

--- a/openeo/extra/job_management/_interface.py
+++ b/openeo/extra/job_management/_interface.py
@@ -32,23 +32,29 @@ class JobDatabaseInterface(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def count_by_status(self, statuses: Iterable[str] = ()) -> dict:
+    def count_by_status(self, statuses: Iterable[str] = (), column: str = "status") -> dict:
         """
         Retrieve the number of jobs per status.
 
         :param statuses: List/set of statuses to include. If empty, all statuses are included.
+        :param column: Which column to filter on. Defaults to ``"status"`` (user-visible lifecycle
+            column). Pass ``"backend_status"`` to count against the official openEO backend status
+            only (NULL for jobs not yet submitted).
 
         :return: dictionary with status as key and the count as value.
         """
         ...
 
     @abc.abstractmethod
-    def get_by_status(self, statuses: List[str], max=None) -> pd.DataFrame:
+    def get_by_status(self, statuses: List[str], max=None, column: str = "status") -> pd.DataFrame:
         """
         Returns a dataframe with jobs, filtered by status.
 
         :param statuses: List of statuses to include.
         :param max: Maximum number of jobs to return.
+        :param column: Which column to filter on. Defaults to ``"status"`` (user-visible lifecycle
+            column). Pass ``"backend_status"`` to filter against the official openEO backend status
+            only (NULL for jobs not yet submitted).
 
         :return: DataFrame with jobs filtered by status.
         """

--- a/openeo/extra/job_management/_job_db.py
+++ b/openeo/extra/job_management/_job_db.py
@@ -62,24 +62,28 @@ class FullDataFrameJobDatabase(JobDatabaseInterface):
             self._df = self.read()
         return self._df
 
-    def count_by_status(self, statuses: Iterable[str] = ()) -> dict:
-        status_histogram = self.df.groupby("status").size().to_dict()
+    def count_by_status(self, statuses: Iterable[str] = (), column: str = "status") -> dict:
+        col = self.df[column]
+        status_histogram = col.groupby(col).size().to_dict()
         statuses = set(statuses)
         if statuses:
             status_histogram = {k: v for k, v in status_histogram.items() if k in statuses}
         return status_histogram
 
-    def get_by_status(self, statuses, max=None) -> pd.DataFrame:
+    def get_by_status(self, statuses, max=None, column: str = "status") -> pd.DataFrame:
         """
         Returns a dataframe with jobs, filtered by status.
 
         :param statuses: List of statuses to include.
         :param max: Maximum number of jobs to return.
+        :param column: Which column to filter on. Defaults to ``"status"`` (user-visible lifecycle
+            column). Pass ``"backend_status"`` to filter against the official openEO backend status
+            only (NULL for jobs not yet submitted).
 
         :return: DataFrame with jobs filtered by status.
         """
         df = self.df
-        filtered = df[df.status.isin(statuses)]
+        filtered = df[df[column].isin(statuses)]
         return filtered.head(max) if max is not None else filtered
 
     def _merge_into_df(self, df: pd.DataFrame):
@@ -147,6 +151,9 @@ class CsvJobDatabase(FullDataFrameJobDatabase):
             # `df.to_csv()` in `persist()` has encoded geometries as WKT, so we decode that here.
             df.geometry = geopandas.GeoSeries.from_wkt(df["geometry"])
             df = geopandas.GeoDataFrame(df)
+        # Backwards compatibility: add backend_status column when reading older files that don't have it.
+        if "backend_status" not in df.columns:
+            df["backend_status"] = None
         return df
 
     def persist(self, df: pd.DataFrame):
@@ -195,9 +202,13 @@ class ParquetJobDatabase(FullDataFrameJobDatabase):
         if b"geo" in metadata.metadata:
             import geopandas
 
-            return geopandas.read_parquet(self.path)
+            df = geopandas.read_parquet(self.path)
         else:
-            return pd.read_parquet(self.path)
+            df = pd.read_parquet(self.path)
+        # Backwards compatibility: add backend_status column when reading older files that don't have it.
+        if "backend_status" not in df.columns:
+            df["backend_status"] = None
+        return df
 
     def persist(self, df: pd.DataFrame):
         self._merge_into_df(df)

--- a/openeo/extra/job_management/_job_db.py
+++ b/openeo/extra/job_management/_job_db.py
@@ -151,8 +151,10 @@ class CsvJobDatabase(FullDataFrameJobDatabase):
             # `df.to_csv()` in `persist()` has encoded geometries as WKT, so we decode that here.
             df.geometry = geopandas.GeoSeries.from_wkt(df["geometry"])
             df = geopandas.GeoDataFrame(df)
-        # Backwards compatibility: add backend_status column when reading older files that don't have it.
-        if "backend_status" not in df.columns:
+        # Backwards compatibility: add backend_status column when reading an older job database
+        # file that pre-dates the status/backend_status split.  Only applies when the file
+        # already has a "status" column (i.e. it is a genuine job management database).
+        if "status" in df.columns and "backend_status" not in df.columns:
             df["backend_status"] = None
         return df
 
@@ -205,8 +207,10 @@ class ParquetJobDatabase(FullDataFrameJobDatabase):
             df = geopandas.read_parquet(self.path)
         else:
             df = pd.read_parquet(self.path)
-        # Backwards compatibility: add backend_status column when reading older files that don't have it.
-        if "backend_status" not in df.columns:
+        # Backwards compatibility: add backend_status column when reading an older job database
+        # file that pre-dates the status/backend_status split.  Only applies when the file
+        # already has a "status" column (i.e. it is a genuine job management database).
+        if "status" in df.columns and "backend_status" not in df.columns:
             df["backend_status"] = None
         return df
 

--- a/openeo/extra/job_management/_manager.py
+++ b/openeo/extra/job_management/_manager.py
@@ -94,13 +94,6 @@ class _ColumnRequirements:
         """
         new_columns = {col: req.default for (col, req) in self._requirements.items() if col not in df.columns}
         df = df.assign(**new_columns)
-        # Ensure columns declared as "str" are object dtype even when the caller
-        # provided all-NaN values (e.g. float("nan")), which pandas would otherwise
-        # infer as float64.  A float64 column cannot accept string assignments later
-        # (e.g. setting running_start_time to an ISO-8601 string in _track_statuses).
-        for col, req in self._requirements.items():
-            if req.dtype == "str" and col in df.columns and df[col].dtype.kind in ("f", "i"):
-                df[col] = df[col].astype(object)
         return df
 
     def dtype_mapping(self) -> Dict[str, str]:

--- a/openeo/extra/job_management/_manager.py
+++ b/openeo/extra/job_management/_manager.py
@@ -199,13 +199,14 @@ class MultiBackendJobManager:
             # TODO: use proper date/time dtype instead of legacy str for start times?
             "start_time": _ColumnProperties(dtype="str"),
             "costs": _ColumnProperties(dtype="float64"),
-            # --- Less prominent / internal columns (right) ---
+            # --- usage metrics (right) ---
             # TODO: these columns "cpu", "memory", "duration" are not referenced explicitly from MultiBackendJobManager,
             #       but are indirectly coupled through handling of VITO-specific "usage" metadata in `_track_statuses`.
             #       Since bfd99e34 they are not really required to be present anymore, can we make that more explicit?
             "cpu": _ColumnProperties(dtype="str"),
             "memory": _ColumnProperties(dtype="str"),
             "duration": _ColumnProperties(dtype="str"),
+            # --- internal bookkeeping ---
             "running_start_time": _ColumnProperties(dtype="str"),
             # Official openEO backend status, as last reported by the backend API.
             # None until the job has been submitted. Only written by _launch_job (initial value)

--- a/openeo/extra/job_management/_manager.py
+++ b/openeo/extra/job_management/_manager.py
@@ -179,12 +179,19 @@ class MultiBackendJobManager:
 
     # Expected columns in the job DB dataframes.
     # TODO: make this part of public API when settled?
-    # TODO: move non official statuses to separate column (not_started, queued_for_start)
     _column_requirements: _ColumnRequirements = _ColumnRequirements(
         {
             "id": _ColumnProperties(dtype="str"),
             "backend_name": _ColumnProperties(dtype="str"),
+            # User-visible lifecycle status. Starts at "not_started" and carries both official
+            # openEO backend statuses (created/queued/running/finished/error/canceled) and internal
+            # housekeeping values (queued_for_start, start_failed, skipped, …). This is the column
+            # users observe and may extend with their own states (e.g. "downloading").
             "status": _ColumnProperties(dtype="str", default="not_started"),
+            # Official openEO backend status, as last reported by the backend API.
+            # None until the job has been submitted. Only written by _launch_job (initial value)
+            # and _track_statuses (every poll). Never carries internal housekeeping values.
+            "backend_status": _ColumnProperties(dtype="str", default=None),
             # TODO: use proper date/time dtype instead of legacy str for start times?
             "start_time": _ColumnProperties(dtype="str"),
             "running_start_time": _ColumnProperties(dtype="str"),
@@ -545,10 +552,11 @@ class MultiBackendJobManager:
         not_started = job_db.get_by_status(statuses=["not_started"], max=200).copy()
         if len(not_started) > 0:
             # Check number of jobs queued/running at each backend
-            # TODO: should "created" be included in here? Calling this "running" is quite misleading then.
-            #       apparently (see #839/#840) this seemingly simple change makes a lot of MultiBackendJobManager tests flaky
-            running = job_db.get_by_status(statuses=["created", "queued", "queued_for_start", "running"])
-            queued = running[running["status"] == "queued"]
+            # Count jobs that are actually active on a backend, using the official backend_status
+            # column. This correctly includes queued_for_start jobs (backend_status="created") and
+            # excludes jobs that have not yet been submitted (backend_status is None/NaN).
+            running = job_db.get_by_status(statuses=["created", "queued", "running"], column="backend_status")
+            queued = running[running["backend_status"] == "queued"]
             running_per_backend = running.groupby("backend_name").size().to_dict()
             queued_per_backend = queued.groupby("backend_name").size().to_dict()
             _log.info(f"{running_per_backend=} {queued_per_backend=}")
@@ -629,6 +637,9 @@ class MultiBackendJobManager:
                 with ignore_connection_errors(context="get status"):
                     status = job.status()
                     stats["job get status"] += 1
+                    # Record official backend status (never overwritten by internal states).
+                    df.loc[i, "backend_status"] = status
+                    # User-visible status initially mirrors the backend.
                     df.loc[i, "status"] = status
                     if status == "created":
                         # start job if not yet done by callback
@@ -822,7 +833,9 @@ class MultiBackendJobManager:
         """
         stats = stats if stats is not None else collections.defaultdict(int)
 
-        active = job_db.get_by_status(statuses=["created", "queued", "queued_for_start", "running"]).copy()
+        # Query jobs that are active on the backend using the dedicated backend_status column.
+        # this eliminates the race condition where _track_statuses would overwrite those states.
+        active = job_db.get_by_status(statuses=["created", "queued", "running"], column="backend_status").copy()
 
         jobs_done = []
         jobs_error = []
@@ -831,6 +844,7 @@ class MultiBackendJobManager:
         for i in active.index:
             job_id = active.loc[i, "id"]
             backend_name = active.loc[i, "backend_name"]
+            # Read the 'job manager' internal state.
             previous_status = active.loc[i, "status"]
 
             try:
@@ -870,7 +884,18 @@ class MultiBackendJobManager:
 
                     self._cancel_prolonged_job(the_job, active.loc[i])
 
-                active.loc[i, "status"] = new_status
+                # Always record the official backend-reported status.
+                active.loc[i, "backend_status"] = new_status
+
+                # Mirror backend status into user-visible status, EXCEPT when status is an internal
+                # "awaiting start" state and the backend still reports "created" (the start request
+                # has not been confirmed yet, or the submit itself failed). Overwriting those states
+                # would race with the thread pool result and hide the internal lifecycle value.
+                _INTERNAL_THREAD_STATUS = {"queued_for_start", "queued_for_start_failed"}
+                if previous_status in _INTERNAL_THREAD_STATUS and new_status == "created":
+                    pass  # keep user-visible status; start not yet confirmed by the backend
+                else:
+                    active.loc[i, "status"] = new_status
 
                 # TODO: there is well hidden coupling here with "cpu", "memory" and "duration" from `_normalize_df`
                 for key in job_metadata.get("usage", {}).keys():

--- a/openeo/extra/job_management/_manager.py
+++ b/openeo/extra/job_management/_manager.py
@@ -188,6 +188,7 @@ class MultiBackendJobManager:
     # TODO: make this part of public API when settled?
     _column_requirements: _ColumnRequirements = _ColumnRequirements(
         {
+            # --- User-facing columns (left) ---
             "id": _ColumnProperties(dtype="str"),
             "backend_name": _ColumnProperties(dtype="str"),
             # User-visible lifecycle status. Starts at "not_started" and carries both official
@@ -195,20 +196,21 @@ class MultiBackendJobManager:
             # housekeeping values (queued_for_start, start_failed, skipped, …). This is the column
             # users observe and may extend with their own states (e.g. "downloading").
             "status": _ColumnProperties(dtype="str", default="not_started"),
-            # Official openEO backend status, as last reported by the backend API.
-            # None until the job has been submitted. Only written by _launch_job (initial value)
-            # and _track_statuses (every poll). Never carries internal housekeeping values.
-            "backend_status": _ColumnProperties(dtype="str", default=None),
             # TODO: use proper date/time dtype instead of legacy str for start times?
             "start_time": _ColumnProperties(dtype="str"),
-            "running_start_time": _ColumnProperties(dtype="str"),
+            "costs": _ColumnProperties(dtype="float64"),
+            # --- Less prominent / internal columns (right) ---
             # TODO: these columns "cpu", "memory", "duration" are not referenced explicitly from MultiBackendJobManager,
             #       but are indirectly coupled through handling of VITO-specific "usage" metadata in `_track_statuses`.
             #       Since bfd99e34 they are not really required to be present anymore, can we make that more explicit?
             "cpu": _ColumnProperties(dtype="str"),
             "memory": _ColumnProperties(dtype="str"),
             "duration": _ColumnProperties(dtype="str"),
-            "costs": _ColumnProperties(dtype="float64"),
+            "running_start_time": _ColumnProperties(dtype="str"),
+            # Official openEO backend status, as last reported by the backend API.
+            # None until the job has been submitted. Only written by _launch_job (initial value)
+            # and _track_statuses (every poll). Never carries internal housekeeping values.
+            "backend_status": _ColumnProperties(dtype="str", default=None),
         }
     )
 
@@ -851,7 +853,6 @@ class MultiBackendJobManager:
         for i in active.index:
             job_id = active.loc[i, "id"]
             backend_name = active.loc[i, "backend_name"]
-            # Read the 'job manager' internal state.
             previous_status = active.loc[i, "status"]
 
             try:
@@ -860,16 +861,21 @@ class MultiBackendJobManager:
                 job_metadata = the_job.describe()
                 stats["job describe"] += 1
                 new_status = job_metadata["status"]
+                # Use the previous *backend* status for transition detection,
+                # so we never have to reason about internal states (queued_for_start, etc.).
+                previous_backend_status = active.loc[i, "backend_status"]
 
                 _log.info(
-                    f"Status of job {job_id!r} (on backend {backend_name}) is {new_status!r} (previously {previous_status!r})"
+                    f"Status of job {job_id!r} (on backend {backend_name}) is {new_status!r}"
+                    f" (previous backend status {previous_backend_status!r})"
                 )
 
-                if previous_status != "finished" and new_status == "finished":
+                # --- Detect backend-level transitions ---
+                if previous_backend_status != "finished" and new_status == "finished":
                     stats["job finished"] += 1
                     jobs_done.append((the_job, active.loc[i]))
 
-                if previous_status != "error" and new_status == "error":
+                if previous_backend_status != "error" and new_status == "error":
                     stats["job failed"] += 1
                     jobs_error.append((the_job, active.loc[i]))
 
@@ -877,7 +883,7 @@ class MultiBackendJobManager:
                     stats["job canceled"] += 1
                     jobs_cancel.append((the_job, active.loc[i]))
 
-                if previous_status in {"created", "queued", "queued_for_start"} and new_status == "running":
+                if previous_backend_status != "running" and new_status == "running":
                     stats["job started running"] += 1
                     active.loc[i, "running_start_time"] = rfc3339.now_utc()
 
@@ -891,18 +897,19 @@ class MultiBackendJobManager:
 
                     self._cancel_prolonged_job(the_job, active.loc[i])
 
+                # --- Update stored statuses ---
                 # Always record the official backend-reported status.
                 active.loc[i, "backend_status"] = new_status
 
+                #TODO consider if still required
                 # Mirror backend status into user-visible status, EXCEPT when status is an internal
                 # "awaiting start" state 
-                _INTERNAL_THREAD_STATUS = {"queued_for_start", "queued_for_start_failed"}
-                if previous_status in _INTERNAL_THREAD_STATUS and new_status == "created":
+                if previous_status in {"queued_for_start", "queued_for_start_failed"} and new_status == "created":
                     pass  # start not yet confirmed by the backend
                 else:
                     active.loc[i, "status"] = new_status
 
-                # TODO: there is well hidden coupling here with "cpu", "memory" and "duration" from `_normalize_df`
+                # --- Update usage / cost metadata ---
                 for key in job_metadata.get("usage", {}).keys():
                     if key in active.columns:
                         active.loc[i, key] = _format_usage_stat(job_metadata, key)

--- a/openeo/extra/job_management/_manager.py
+++ b/openeo/extra/job_management/_manager.py
@@ -524,7 +524,7 @@ class MultiBackendJobManager:
         while (
             sum(
                 job_db.count_by_status(
-                    statuses=["not_started", "created", "queued_for_start", "queued", "running"]
+                    statuses=["not_started","queued_for_start", "created", "queued", "running"]
                 ).values()
             )
             > 0
@@ -566,7 +566,7 @@ class MultiBackendJobManager:
             # column. This correctly includes queued_for_start jobs (backend_status="created") and
             # excludes jobs that have not yet been submitted (backend_status is None/NaN).
             running = job_db.get_by_status(statuses=["created", "queued", "running"], column="backend_status")
-            queued = running[running["backend_status"] == "queued"]
+            queued = running[running["status"].isin(["queued", "queued_for_start"])]
             running_per_backend = running.groupby("backend_name").size().to_dict()
             queued_per_backend = queued.groupby("backend_name").size().to_dict()
             _log.info(f"{running_per_backend=} {queued_per_backend=}")

--- a/openeo/extra/job_management/_manager.py
+++ b/openeo/extra/job_management/_manager.py
@@ -94,6 +94,13 @@ class _ColumnRequirements:
         """
         new_columns = {col: req.default for (col, req) in self._requirements.items() if col not in df.columns}
         df = df.assign(**new_columns)
+        # Enforce object dtype for str-typed columns: pandas infers float64 when all
+        # values are NaN (e.g. the user passes float("nan") for running_start_time).
+        # A float64 column rejects string assignments later (e.g. ISO datetimes in
+        # _track_statuses), so we coerce here where the schema is authoritative.
+        for col, req in self._requirements.items():
+            if req.dtype == "str" and col in df.columns and df[col].dtype.kind in ("f", "i"):
+                df[col] = df[col].astype(object)
         return df
 
     def dtype_mapping(self) -> Dict[str, str]:
@@ -875,7 +882,7 @@ class MultiBackendJobManager:
                     active.loc[i, "running_start_time"] = rfc3339.now_utc()
 
                 if self._cancel_running_job_after and new_status == "running":
-                    if not active.loc[i, "running_start_time"] or pd.isna(active.loc[i, "running_start_time"]):
+                    if pd.isna(active.loc[i, "running_start_time"]):
                         _log.warning(
                             f"Unknown 'running_start_time' for running job {job_id}. Using current time as an approximation."
                         )
@@ -888,9 +895,7 @@ class MultiBackendJobManager:
                 active.loc[i, "backend_status"] = new_status
 
                 # Mirror backend status into user-visible status, EXCEPT when status is an internal
-                # "awaiting start" state and the backend still reports "created" (the start request
-                # has not been confirmed yet, or the submit itself failed). Overwriting those states
-                # would race with the thread pool result and hide the internal lifecycle value.
+                # "awaiting start" state 
                 _INTERNAL_THREAD_STATUS = {"queued_for_start", "queued_for_start_failed"}
                 if previous_status in _INTERNAL_THREAD_STATUS and new_status == "created":
                     pass  # keep user-visible status; start not yet confirmed by the backend

--- a/openeo/extra/job_management/_manager.py
+++ b/openeo/extra/job_management/_manager.py
@@ -94,6 +94,13 @@ class _ColumnRequirements:
         """
         new_columns = {col: req.default for (col, req) in self._requirements.items() if col not in df.columns}
         df = df.assign(**new_columns)
+        # Ensure columns declared as "str" are object dtype even when the caller
+        # provided all-NaN values (e.g. float("nan")), which pandas would otherwise
+        # infer as float64.  A float64 column cannot accept string assignments later
+        # (e.g. setting running_start_time to an ISO-8601 string in _track_statuses).
+        for col, req in self._requirements.items():
+            if req.dtype == "str" and col in df.columns and df[col].dtype.kind in ("f", "i"):
+                df[col] = df[col].astype(object)
         return df
 
     def dtype_mapping(self) -> Dict[str, str]:

--- a/openeo/extra/job_management/_manager.py
+++ b/openeo/extra/job_management/_manager.py
@@ -898,7 +898,7 @@ class MultiBackendJobManager:
                 # "awaiting start" state 
                 _INTERNAL_THREAD_STATUS = {"queued_for_start", "queued_for_start_failed"}
                 if previous_status in _INTERNAL_THREAD_STATUS and new_status == "created":
-                    pass  # keep user-visible status; start not yet confirmed by the backend
+                    pass  # start not yet confirmed by the backend
                 else:
                     active.loc[i, "status"] = new_status
 

--- a/openeo/extra/job_management/stac_job_db.py
+++ b/openeo/extra/job_management/stac_job_db.py
@@ -320,3 +320,6 @@ def _check_response_status(response: requests.Response, expected_status_codes: L
 
     # Always raise errors on 4xx and 5xx status codes.
     response.raise_for_status()
+
+
+

--- a/openeo/extra/job_management/stac_job_db.py
+++ b/openeo/extra/job_management/stac_job_db.py
@@ -155,15 +155,15 @@ class STACAPIJobDatabase(JobDatabaseInterface):
             item.bbox = None
         return item
 
-    def count_by_status(self, statuses: Iterable[str] = ()) -> dict:
+    def count_by_status(self, statuses: Iterable[str] = (), column: str = "status") -> dict:
         if isinstance(statuses, str):
             statuses = {statuses}
         statuses = set(statuses)
-        items = self.get_by_status(statuses)
+        items = self.get_by_status(statuses, column=column)
         if items is None:
             return {k: 0 for k in statuses}
         else:
-            return items["status"].value_counts().to_dict()
+            return items[column].value_counts().to_dict()
 
     def _search_result_to_df(self, search_result: pystac_client.ItemSearch) -> pd.DataFrame:
         """Build a DataFrame from a STAC ItemSearch result."""
@@ -171,12 +171,13 @@ class STACAPIJobDatabase(JobDatabaseInterface):
         df = pd.DataFrame(series).reset_index(names=["item_id"])
         return df
 
-    def get_by_status(self, statuses: Iterable[str], max: Optional[int] = None) -> pd.DataFrame:
+    def get_by_status(self, statuses: Iterable[str], max: Optional[int] = None, column: str = "status") -> pd.DataFrame:
         if isinstance(statuses, str):
             statuses = {statuses}
         statuses = set(statuses)
 
-        status_filter = " OR ".join([f"\"properties.status\"='{s}'" for s in statuses]) if statuses else None
+        filter_field = f"properties.{column}"
+        status_filter = " OR ".join([f'"{filter_field}"=\'{s}\'' for s in statuses]) if statuses else None
         search_results = self.client.search(
             method="GET",
             collections=[self.collection_id],

--- a/tests/extra/job_management/test_job_db.py
+++ b/tests/extra/job_management/test_job_db.py
@@ -49,6 +49,7 @@ class TestFullDataFrameJobDatabase:
         expected_columns = {
             "some_number",
             "status",
+            "backend_status",
             "id",
             "start_time",
             "running_start_time",
@@ -228,6 +229,7 @@ class TestCsvJobDatabase:
         expected_columns = {
             "some_number",
             "status",
+            "backend_status",
             "id",
             "start_time",
             "running_start_time",
@@ -341,7 +343,19 @@ class TestParquetJobDatabase:
         }
 
         df_from_disk = ParquetJobDatabase(path).read()
-        assert set(df_from_disk.columns) == expected_columns
+        assert set(df_from_disk.columns) == {
+            "some_number",
+            "status",
+            "backend_status",
+            "id",
+            "start_time",
+            "running_start_time",
+            "cpu",
+            "memory",
+            "duration",
+            "backend_name",
+            "costs",
+        }
 
 
 @pytest.mark.parametrize(

--- a/tests/extra/job_management/test_manager.py
+++ b/tests/extra/job_management/test_manager.py
@@ -298,6 +298,7 @@ class TestMultiBackendJobManager:
             [
                 "some_number",
                 "status",
+                "backend_status",
                 "id",
                 "start_time",
                 "running_start_time",

--- a/tests/extra/job_management/test_stac_job_db.py
+++ b/tests/extra/job_management/test_stac_job_db.py
@@ -62,6 +62,7 @@ def _common_normalized_df_data(rows: int = 1) -> dict:
         "id": None,
         "backend_name": None,
         "status": ["not_started"] * rows,
+        "backend_status": [None] * rows,
         "start_time": None,
         "running_start_time": None,
         "cpu": None,
@@ -578,11 +579,17 @@ class DummyStacApi:
             [property_filter] = request.qs["filter"]
             # TODO: use a more robust CQL2-text parser?
             assert request.qs["filter-lang"] == ["cql2-text"]
+            # Match filters on any properties.<field> column (e.g. status or backend_status)
             assert re.match(
-                r"^\s*\"properties\.status\"='\w+'(\s+or\s+\"properties\.status\"='\w+')*\s*$", property_filter
+                r"^\s*\"properties\.\w+\"='\w+'(\s+OR\s+\"properties\.\w+\"='\w+')*\s*$",
+                property_filter,
+                re.IGNORECASE,
             )
-            statuses = set(re.findall(r"\"properties\.status\"='(\w+)'", property_filter))
-            items = [i for i in items if i.get("properties", {}).get("status") in statuses]
+            # Extract the field name from the first clause
+            field_match = re.search(r'"properties\.(\w+)"', property_filter)
+            field = field_match.group(1) if field_match else "status"
+            statuses = set(re.findall(rf'"properties\.{field}"=\'(\w+)\'', property_filter))
+            items = [i for i in items if i.get("properties", {}).get(field) in statuses]
 
         return {
             "type": "FeatureCollection",

--- a/tests/extra/job_management/test_stac_job_db.py
+++ b/tests/extra/job_management/test_stac_job_db.py
@@ -57,18 +57,20 @@ def _common_normalized_df_data(rows: int = 1) -> dict:
     with common columns that are the result of normalization.
     In the context of these tests however, they are
     mainly irrelevant boilerplate data that is tedious to repeat.
+
+    Note: column order must match ``MultiBackendJobManager._column_requirements``.
     """
     return {
         "id": None,
         "backend_name": None,
         "status": ["not_started"] * rows,
-        "backend_status": [None] * rows,
         "start_time": None,
-        "running_start_time": None,
+        "costs": None,
         "cpu": None,
         "memory": None,
         "duration": None,
-        "costs": None,
+        "running_start_time": None,
+        "backend_status": [None] * rows,
     }
 
 


### PR DESCRIPTION
Draft PR; 

The main logic now looks at a seperate column which only contains the backend-status. The status column remained unchanged. 

I did reshuffle the columns to place the internal logic ones all the way to the right. 