### PR TITLE
Revert "Allow message as first un-named argument. "

### DIFF
--- a/openeo/rest/__init__.py
+++ b/openeo/rest/__init__.py
@@ -81,10 +81,10 @@ class OpenEoApiError(OpenEoApiPlainError):
 
     def __init__(
         self,
-        message: str,
         *,
         http_status_code: int,
         code: str,
+        message: str,
         id: Optional[str] = None,
         url: Optional[str] = None,
     ):


### PR DESCRIPTION
Reverts Open-EO/openeo-python-client#895
It did not fix the issue, so best to make no change.