### PR TITLE
[codex] support parameters in DataCube binary operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Support `Parameter` values in `DataCube` binary operators outside band math mode. ([#903](https://github.com/Open-EO/openeo-python-client/issues/903))
+
 ## [0.50.0] - 2026-05-18
 
 ### Added

--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -877,7 +877,7 @@ class DataCube(_ProcessGraphAbstraction):
             dict_no_none({"data": self, "target": target, "dimension": dimension, "valid_within": valid_within})
         )
 
-    def _operator_binary(self, operator: str, other: Union[DataCube, int, float], reverse=False) -> DataCube:
+    def _operator_binary(self, operator: str, other: Union[DataCube, int, float, Parameter], reverse=False) -> DataCube:
         """Generic handling of (mathematical) binary operator"""
         band_math_mode = self._in_bandmath_mode()
         if band_math_mode:
@@ -888,7 +888,7 @@ class DataCube(_ProcessGraphAbstraction):
         else:
             if isinstance(other, DataCube):
                 return self._merge_operator_binary_cubes(operator, other)
-            elif isinstance(other, (int, float)):
+            elif isinstance(other, (int, float, Parameter)):
                 # "`apply` math" mode
                 return self._apply_operator(
                     operator=operator, other=other, reverse=reverse
@@ -907,7 +907,7 @@ class DataCube(_ProcessGraphAbstraction):
     def _apply_operator(
         self,
         operator: str,
-        other: Optional[Union[int, float]] = None,
+        other: Optional[Union[int, float, Parameter]] = None,
         reverse: Optional[bool] = None,
         extra_arguments: Optional[dict] = None,
     ) -> DataCube:

--- a/tests/rest/datacube/test_datacube100.py
+++ b/tests/rest/datacube/test_datacube100.py
@@ -3628,6 +3628,11 @@ def test_update_arguments_priority(con100):
     (lambda c: 4 > c, "lt", {"x": {"from_parameter": "x"}, "y": 4}),
     (lambda c: c == 4, "eq", {"x": {"from_parameter": "x"}, "y": 4}),
     (lambda c: 4 == c, "eq", {"x": {"from_parameter": "x"}, "y": 4}),
+    (
+        lambda c: c >= Parameter.number("threshold"),
+        "gte",
+        {"x": {"from_parameter": "x"}, "y": {"from_parameter": "threshold"}},
+    ),
 ])
 def test_apply_math_simple(con100, math, process, args):
     """https://github.com/Open-EO/openeo-python-client/issues/323"""


### PR DESCRIPTION
## Summary

- allow `Parameter` values in `DataCube` binary operators outside band math mode
- add a regression case for `cube >= Parameter.number("threshold")`
- document the fix in the unreleased changelog

Closes Open-EO/openeo-python-client#903.

## Validation

- Red test before implementation: `python3 -m pytest tests/rest/datacube/test_datacube100.py::test_apply_math_simple -q` failed with `Unsupported operator 'gte' ... Parameter`
- `.venv/bin/python -m pytest tests/rest/datacube/test_datacube100.py::test_apply_math_simple -q`
- `.venv/bin/python -m pytest tests/rest/datacube/test_datacube.py tests/rest/datacube/test_datacube100.py -q`
- `.venv/bin/python -m compileall openeo/rest/datacube.py tests/rest/datacube/test_datacube100.py`
- `git diff --check`

Note: `.venv/bin/python -m flake8 openeo/rest/datacube.py tests/rest/datacube/test_datacube100.py` reports pre-existing file-level lint violations outside this patch.
