### PR TITLE
Improve spatial extent bbox error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Report missing bounding-box fields clearly for `load_collection()` and `load_stac()` spatial extents. ([#910](https://github.com/Open-EO/openeo-python-client/issues/910))
+
 ## [0.50.0] - 2026-05-18
 
 ### Added

--- a/openeo/rest/datacube.py
+++ b/openeo/rest/datacube.py
@@ -3170,12 +3170,16 @@ def _get_geometry_argument(
         return argument.from_node()
     elif allow_none and argument is None:
         return argument
-    elif (
-        allow_bounding_box
-        and isinstance(argument, dict)
-        and all(k in argument for k in ["west", "south", "east", "north"])
-    ):
-        return argument
+    elif allow_bounding_box and isinstance(argument, dict):
+        bbox_fields = {"west", "south", "east", "north"}
+        missing_bbox_fields = bbox_fields.difference(argument)
+        if not missing_bbox_fields:
+            return argument
+        if bbox_fields.intersection(argument) and not argument.get("type"):
+            raise OpenEoClientException(
+                f"Invalid bounding box given to `{argument_name}` in `{process_id}`: "
+                f"missing fields {sorted(missing_bbox_fields)}."
+            )
 
     # Support URL based geometry references (with `load_url` and best-effort format guess)
     if isinstance(argument, str) and re.match(r"^https?://", argument, flags=re.I):

--- a/tests/rest/test_connection.py
+++ b/tests/rest/test_connection.py
@@ -2883,6 +2883,16 @@ class TestLoadCollection:
             "temporal_extent": None,
         }
 
+    def test_load_collection_spatial_extent_bbox_missing_field(self, dummy_backend):
+        spatial_extent = {"west": 3.1, "south": 51.1, "east": 3.2, "norht": 51.2}
+        with pytest.raises(
+            OpenEoClientException,
+            match=re.escape(
+                "Invalid bounding box given to `spatial_extent` in `load_collection`: missing fields ['north']."
+            ),
+        ):
+            dummy_backend.connection.load_collection("S2", spatial_extent=spatial_extent)
+
     @pytest.mark.parametrize(
         "spatial_extent",
         [
@@ -3626,6 +3636,14 @@ class TestLoadStac:
             "url": "https://stac.test/data",
             "spatial_extent": {"west": 1, "south": 2, "east": 3, "north": 4},
         }
+
+    def test_load_stac_spatial_extent_bbox_missing_field(self, dummy_backend):
+        spatial_extent = {"west": 3.1, "south": 51.1, "east": 3.2, "norht": 51.2}
+        with pytest.raises(
+            OpenEoClientException,
+            match=re.escape("Invalid bounding box given to `spatial_extent` in `load_stac`: missing fields ['north']."),
+        ):
+            dummy_backend.connection.load_stac("https://stac.test/data", spatial_extent=spatial_extent)
 
     @pytest.mark.parametrize(
         "spatial_extent",


### PR DESCRIPTION
Summary:
- detect incomplete bounding-box mappings before treating them as GeoJSON
- report the required fields that are missing for load_collection and load_stac
- cover the reported misspelled-field case and document the fix in the changelog

Testing:
- focused bbox regression tests: 2 passed
- related spatial-extent tests: 46 passed
- repository pre-commit hooks
- strict project Flake8 and Python compilation
- full-suite comparison against the same clean base: identical 13 environment-only failures, with the branch adding two passing tests

Fixes #910