### PR TITLE
test_warnings.py: fix SyntaxWarnings

### DIFF
--- a/tests/internal/test_warnings.py
+++ b/tests/internal/test_warnings.py
@@ -102,8 +102,8 @@ def test_legacy_alias_classmethod(recwarn):
 
     expected_warning = (
         r"Call to deprecated .*(method|function).* do_plus\."
-        " \(Usage of this legacy .*(method|function).* is deprecated\. Use `\.add` instead\.\)"
-        " -- Deprecated since version v1\.2\."
+        r" \(Usage of this legacy .*(method|function).* is deprecated\. Use `\.add` instead\.\)"
+        r" -- Deprecated since version v1\.2\."
     )
 
     with pytest.warns(UserDeprecationWarning, match=expected_warning):


### PR DESCRIPTION
Add the missing r-qualifier on the strings
to fix the two warnings about invalid
escape sequences.